### PR TITLE
Use more serial devices on Mac OS X

### DIFF
--- a/libnfc/buses/uart.c
+++ b/libnfc/buses/uart.c
@@ -74,7 +74,7 @@
 #endif
 
 #  if defined(__APPLE__)
-const char *serial_ports_device_radix[] = { "tty.SLAB_USBtoUART", "tty.usbserial-", NULL };
+const char *serial_ports_device_radix[] = { "tty.SLAB_USBtoUART", "tty.usbserial", "tty.usbmodem", NULL };
 #  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined(__FreeBSD_kernel__)
 const char *serial_ports_device_radix[] = { "cuaU", "cuau", NULL };
 #  elif defined (__linux__)


### PR DESCRIPTION
Some USB-serial adapters just use tty.usbserial or tty.usbmodem as a
device name. (e.g.
Prolific).  Currently part of a patch for homebrew here:
https://github.com/Homebrew/homebrew/blob/master/Library/Formula/libnfc.
rb