### PR TITLE
Fix nfc_initiator_poll_target without tag on PN532

### DIFF
--- a/libnfc/chips/pn53x.c
+++ b/libnfc/chips/pn53x.c
@@ -1226,6 +1226,9 @@ pn53x_initiator_poll_target(struct nfc_device *pnd,
     if ((res = pn53x_InAutoPoll(pnd, apttTargetTypes, szTargetTypes, uiPollNr, uiPeriod, ntTargets, 0)) < 0)
       return res;
     switch (res) {
+      case 0:
+        return pnd->last_error = NFC_SUCCESS;
+        break;
       case 1:
         *pnt = ntTargets[0];
         if (pn53x_current_target_new(pnd, pnt) == NULL) {


### PR DESCRIPTION
When there is no tag on PN532 reader, the library
incorrectly processed call result and returned
NFC_ECHIP (chip error) instead of 0 (no targets
found).