### PR TITLE
Fix nfc-poll card removing check

### DIFF
--- a/examples/nfc-poll.c
+++ b/examples/nfc-poll.c
@@ -145,14 +145,13 @@ main(int argc, const char *argv[])
 
   if (res > 0) {
     print_nfc_target(&nt, verbose);
+    printf("Waiting for card removing...");
+    while (0 == nfc_initiator_target_is_present(pnd, NULL)) {}
+    nfc_perror(pnd, "nfc_initiator_target_is_present");
+    printf("done.\n");
   } else {
     printf("No target found.\n");
   }
-
-  printf("Waiting for card removing...");
-  while (0 == nfc_initiator_target_is_present(pnd, NULL)) {}
-  nfc_perror(pnd, "nfc_initiator_target_is_present");
-  printf("done.\n");
 
   nfc_close(pnd);
   nfc_exit(context);


### PR DESCRIPTION
When the polling ends without having found any target, `nfc_initiator_target_is_present` fails due to invalid argument because the code is executed in both cases (target found or not).

> No target found.
> nfc_initiator_target_is_present: Invalid argument(s)
> Waiting for card removing...done.
