### PR TITLE
Unlock read/write magic card fallback

### DIFF
--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -314,6 +314,7 @@ read_card(int read_unlocked)
     //need to use the R mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (R) \n");
+      read_unlocked = 0;
     } else {
       //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
@@ -393,6 +394,7 @@ write_card(int write_block_zero)
     //need to use the W mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (W) \n");
+      write_block_zero = 0
     } else {
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -309,7 +309,7 @@ read_card(int read_unlocked)
   bool    bFailure = false;
   uint32_t uiReadBlocks = 0;
 
-  if (read_unlocke) {
+  if (read_unlocked) {
     //If the user is attempting an unlocked read, but has a direct-write type magic card, they don't 
     //need to use the R mode. We'll trigger a warning and let them proceed.
     if (magic2) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -394,7 +394,7 @@ write_card(int write_block_zero)
     //need to use the W mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (W) \n");
-      write_block_zero = 0
+      write_block_zero = 0;
     } else {
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -233,11 +233,6 @@ authenticate(uint32_t uiBlock)
 static bool
 unlock_card(void)
 {
-  if (magic2) {
-    printf("Don't use R/W with this card, this is not required!\n");
-    return false;
-  }
-
   // Configure the CRC
   if (nfc_device_set_property_bool(pnd, NP_HANDLE_CRC, false) < 0) {
     nfc_perror(pnd, "nfc_configure");
@@ -314,9 +309,17 @@ read_card(int read_unlocked)
   bool    bFailure = false;
   uint32_t uiReadBlocks = 0;
 
-  if (read_unlocked)
-    if (!unlock_card())
-      return false;
+  if (read_unlocke) {
+    //If the user is attempting an unlocked read, but has a direct-write type magic card, they don't 
+    //need to use the R mode. We'll trigger a warning and let them proceed.
+    if (magic2) {
+      printf("Note: This card does not require an unlocked write (R) \n");
+    } else {
+      //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
+      if (!unlock_card()) {
+        return false; 
+    }
+  }
 
   printf("Reading out %d blocks |", uiBlocks + 1);
   // Read the card from end to begin
@@ -384,9 +387,17 @@ write_card(int write_block_zero)
   bool    bFailure = false;
   uint32_t uiWriteBlocks = 0;
 
-  if (write_block_zero)
-    if (!unlock_card())
-      return false;
+  if (write_block_zero) {
+    //If the user is attempting an unlocked write, but has a direct-write type magic card, they don't 
+    //need to use the W mode. We'll trigger a warning and let them proceed.
+    if (magic2) {
+      printf("Note: This card does not require an unlocked write (W) \n");
+    } else {
+      //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
+      if (!unlock_card()) {
+        return false; 
+    }
+  }
 
   printf("Writing %d blocks |", uiBlocks + 1);
   // Write the card from begin to end;

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -318,9 +318,10 @@ read_card(int read_unlocked)
       //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
         return false; 
+      }
     }
   }
-
+  
   printf("Reading out %d blocks |", uiBlocks + 1);
   // Read the card from end to begin
   for (iBlock = uiBlocks; iBlock >= 0; iBlock--) {
@@ -396,9 +397,10 @@ write_card(int write_block_zero)
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
         return false; 
+      }
     }
   }
-
+  
   printf("Writing %d blocks |", uiBlocks + 1);
   // Write the card from begin to end;
   for (uiBlock = 0; uiBlock <= uiBlocks; uiBlock++) {


### PR DESCRIPTION
*Current Situation*
- nfc-mfclassic knows two types of magic cards: direct-write, or 'full magic' cards. 
- 'Full magic' cards can use the R/W flags [fully unlocked read / writes]
- 'Direct Write' cards are designated by the 'magic2' flag, and must use the w/r flags.
If a 'Direct Write' card is used with a R/W flag, an error is thrown, and the program halts

*Proposed Situation*
- If a 'Direct Write' card is used with a R/W flag, a warning is shown, and the program gracefully degrades to 'standard' operation for Direct Write cards.
This seems to be a more logical behavior, allowing a user to place their 'magic' card (of any type) - using the 'R/W' flags, and getting a known result - useful in automated situations.

This code has been tested with both types of magic cards, and works perfectly.
Thank you for your consideration.

Direct Write card, with R flag given (New behavior)
```
sudo ./nfc-mfclassic R a /tmp/testdump1.dmp
NFC reader: pn532_uart:/dev/ttyAMA0 opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  02
       UID (NFCID1): ec  6b  91  7f
      SAK (SEL_RES): 18
Guessing size: seems to be a 4096-byte card
Note: This card does not require an unlocked write (R)
Reading out 256 blocks |................................................................................................................................................................................................................................................................|
Done, 256 of 256 blocks read.
Writing data to file: /tmp/testdump1.dmp ...Done.
```

Direct Write card, with r flag given (Standard behavior)
```
sudo ./nfc-mfclassic r a /tmp/testdump1.dmp
NFC reader: pn532_uart:/dev/ttyAMA0 opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  02
       UID (NFCID1): ec  6b  91  7f
      SAK (SEL_RES): 18
Guessing size: seems to be a 4096-byte card
Reading out 256 blocks |................................................................................................................................................................................................................................................................|
Done, 256 of 256 blocks read.
Writing data to file: /tmp/testdump1.dmp ...Done.
```

Direct Write card, with W flag given (New behavior)
```
sudo ./nfc-mfclassic W a /tmp/testdump1.dmp
NFC reader: pn532_uart:/dev/ttyAMA0 opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  02
       UID (NFCID1): ec  6b  91  7f
      SAK (SEL_RES): 18
Guessing size: seems to be a 4096-byte card
Note: This card does not require an unlocked write (W)
Writing 256 blocks |................................................................................................................................................................................................................................................................|
Done, 256 of 256 blocks written.
```

Direct Write card, with w flag given (Standard behavior)
```
sudo ./nfc-mfclassic w a /tmp/testdump1.dmp
NFC reader: pn532_uart:/dev/ttyAMA0 opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  02
       UID (NFCID1): ec  6b  91  7f
      SAK (SEL_RES): 18
Guessing size: seems to be a 4096-byte card
Writing 256 blocks |................................................................................................................................................................................................................................................................|
```