### PR TITLE
Extends nfc-mfultralight functionality (Magic cards, unattended mode)

### DIFF
--- a/utils/nfc-mfultralight.c
+++ b/utils/nfc-mfultralight.c
@@ -385,6 +385,8 @@ main(int argc, const char *argv[])
   } else if (iAction == 3) {
     if (!check_magic()) {
         printf("Card is not magic\n");
+        nfc_close(pnd);
+        nfc_exit(context);
         exit(EXIT_FAILURE);
     } else {
         printf("Card is magic\n");


### PR DESCRIPTION
PR goal is to extend functionality for Magic UL cards.
 - Added CLI flag: --check-magic - checks to see if the detected card is a mifare ultralight magic card

 - Added various CLI flags to allow for unattended operation
   - --otp will automatically write the OTP
   - --lock will automatically write the lockbits
  - --uid will automatically write the UID
  - --full will write the entire card (UID, Lockbits, OTP, data..)

 - Cleaned up help
 - Cleaned up typos