### PR TITLE
fixed size error when creating dump files of mfclassic

### DIFF
--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -669,7 +669,7 @@ main(int argc, const char *argv[])
       magic2 = true;
     }
   }
-  printf("Guessing size: seems to be a %i-byte card\n", (uiBlocks + 1) * 16);
+  printf("Guessing size: seems to be a %i-byte card\n", (uiBlocks + 1) * sizeof(mifare_classic_block));
 
   if (bUseKeyFile) {
     FILE *pfKeys = fopen(argv[4], "rb");
@@ -686,7 +686,7 @@ main(int argc, const char *argv[])
   }
 
   if (atAction == ACTION_READ) {
-    memset(&mtDump, 0x00, sizeof(mtDump));
+    memset(&mtDump, 0x00, (uiBlocks + 1) * sizeof(mifare_classic_block));
   } else {
     FILE *pfDump = fopen(argv[3], "rb");
 


### PR DESCRIPTION
When reading mifare classic cards, dump files were created of 4K size regardless the card type. Fix in line 689 solves this issue, creating a dump file of the same size than the card being dumped.
