### PR TITLE
Updates contrib examples to use new format.

### DIFF
--- a/contrib/libnfc/arygon.conf.sample
+++ b/contrib/libnfc/arygon.conf.sample
@@ -1,3 +1,3 @@
 ## Typical configuration file for Arygon/IDentive device (with Arygon-MCU on board)
-name = "IDentive"
-connstring = arygon:/dev/ttyS0
+device.name = "IDentive"
+device.connstring = arygon:/dev/ttyS0

--- a/contrib/libnfc/pn532_i2c_on_rpi.conf.sample
+++ b/contrib/libnfc/pn532_i2c_on_rpi.conf.sample
@@ -2,8 +2,8 @@
 ## Note: to use SPI port on R-Pi, you have to load kernel modules i2c-bcm2708 and i2c-dev:
 ## Edit /etc/modprobe.d/raspi-blacklist.conf and comment: #blacklist i2c-bcm2708
 ## Edit /etc/modules and add a new line: i2c-dev
-name = "PN532 board via I2C"
-connstring = pn532_i2c:/dev/i2c-0
+device.name = "PN532 board via I2C"
+device.connstring = pn532_i2c:/dev/i2c-0
 
 # Note: If you have an R-Pi revision 2.0, the I2C bus #1 is now routed to connector P1
 # (instead of the I2C bus #0 routed on same connector on initial board revision), so

--- a/contrib/libnfc/pn532_spi_on_rpi.conf.sample
+++ b/contrib/libnfc/pn532_spi_on_rpi.conf.sample
@@ -1,5 +1,5 @@
 ## Typical configuration file for PN532 device on R-Pi connected using SPI
 ## Note: to use SPI port on R-Pi, you have to load kernel module spi-bcm2708:
 ## Edit /etc/modprobe.d/raspi-blacklist.conf and comment: #blacklist spi-bcm2708
-name = "PN532 board via SPI"
-connstring = pn532_spi:/dev/spidev0.0:500000
+device.name = "PN532 board via SPI"
+device.connstring = pn532_spi:/dev/spidev0.0:500000

--- a/contrib/libnfc/pn532_uart_on_rpi.conf.sample
+++ b/contrib/libnfc/pn532_uart_on_rpi.conf.sample
@@ -1,5 +1,5 @@
 ## Typical configuration file for PN532 device on R-Pi connected using UART
 ## Note: to use UART port on R-Pi, you have to disable linux serial console:
 ##   http://learn.adafruit.com/adafruit-nfc-rfid-on-raspberry-pi/freeing-uart-on-the-pi
-name = "PN532 board via UART"
-connstring = pn532_uart:/dev/ttyAMA0
+device.name = "PN532 board via UART"
+device.connstring = pn532_uart:/dev/ttyAMA0

--- a/contrib/libnfc/pn532_via_uart2usb.conf.sample
+++ b/contrib/libnfc/pn532_via_uart2usb.conf.sample
@@ -1,3 +1,3 @@
 ## Typical configuration file for PN532 board (ie. microbuilder.eu / Adafruit) device
-name = "Adafruit PN532 board via UART"
-connstring = pn532_uart:/dev/ttyUSB0
+device.name = "Adafruit PN532 board via UART"
+device.connstring = pn532_uart:/dev/ttyUSB0


### PR DESCRIPTION
- Resolves issue #335.
- At some point, the conf file format appears to be updated to need `device.X`, but these contrib samples were never updated.
- I have verified the PN532 board via UART, as that's what I use, I have not tried the others but it's my understanding that they the update as well.