### PR TITLE
added support for ACR1222U-C1

### DIFF
--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -262,6 +262,7 @@ struct acr122_usb_supported_device {
 const struct acr122_usb_supported_device acr122_usb_supported_devices[] = {
   { 0x072F, 0x2200, "ACS ACR122" },
   { 0x072F, 0x90CC, "Touchatag" },
+  { 0x072F, 0x2214, "ACS ACR1222" },
 };
 
 // Find transfer endpoints for bulk transfers


### PR DESCRIPTION
added ACR1222U-C1 ACS ACR1222 1SAM PICC Reader in supported devices