### PR TITLE
drivers: pn532_i2c: Errata on i2c timing

### DIFF
--- a/libnfc/drivers/pn532_i2c.c
+++ b/libnfc/drivers/pn532_i2c.c
@@ -104,7 +104,7 @@ static size_t pn532_i2c_scan(const nfc_context *context, nfc_connstring connstri
  * tBuf in the PN532 data sheet, section 12.25: Timing for the I2C interface,
  * table 320. I2C timing specification, page 211, rev. 3.2 - 2007-12-07.
  */
-#define PN532_BUS_FREE_TIME 1.3
+#define PN532_BUS_FREE_TIME 5
 static struct timespec __transaction_stop;
 
 /**


### PR DESCRIPTION
The datasheet is wrong for the pn532_i2c. After having constant issues
with the device failing to respond on the bus and after contacting NXP
about this, it turns out 1.3 ms is too tight. The official timing spec
is unknown for now, but we tested 4 and 5 ms without problems. Thus we
have choosen 5 ms as a safe delay.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>