### PR TITLE
Adding support for 4K magic cards

### DIFF
--- a/examples/nfc-mfsetuid.c
+++ b/examples/nfc-mfsetuid.c
@@ -365,13 +365,23 @@ main(int argc, char *argv[])
   // now reset UID
   iso14443a_crc_append(abtHalt, 2);
   transmit_bytes(abtHalt, 4);
-  transmit_bits(abtUnlock1, 7);
-  if (format) {
-    transmit_bytes(abtWipe, 1);
-    transmit_bytes(abtHalt, 4);
-    transmit_bits(abtUnlock1, 7);
+
+  if (!transmit_bits(abtUnlock1, 7)) {
+    printf("Warning: Unlock command [1/2]: failed / not acknowledged.\n");
+  } else {
+    if (format) {
+	  transmit_bytes(abtWipe, 1);
+	  transmit_bytes(abtHalt, 4);
+  	  transmit_bits(abtUnlock1, 7);
+    }
+  
+	if (transmit_bytes(abtUnlock2, 1)) {
+		printf("Card unlocked\n");
+	} else {
+		printf("Warning: Unlock command [2/2]: failed / not acknowledged.\n");	
+	}
   }
-  transmit_bytes(abtUnlock2, 1);
+
   transmit_bytes(abtWrite, 4);
   transmit_bytes(abtData, 18);
   if (format) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -70,6 +70,7 @@ static bool bForceKeyFile;
 static bool bTolerateFailures;
 static bool bFormatCard;
 static bool magic2 = false;
+static bool unlocked = false;
 static uint8_t uiBlocks;
 static uint8_t keys[] = {
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -248,12 +249,14 @@ unlock_card(void)
   transmit_bytes(abtHalt, 4);
   // now send unlock
   if (!transmit_bits(abtUnlock1, 7)) {
-    printf("unlock failure!\n");
-    return false;
-  }
-  if (!transmit_bytes(abtUnlock2, 1)) {
-    printf("unlock failure!\n");
-    return false;
+    printf("Warning: Unlock command [1/2]: failed / not acknowledged.\n");
+  } else {
+	if (transmit_bytes(abtUnlock2, 1)) {
+		printf("Card unlocked\n");
+		unlocked = true;
+	} else {
+		printf("Warning: Unlock command [2/2]: failed / not acknowledged.\n");	
+	}
   }
 
   // reset reader
@@ -668,7 +671,7 @@ main(int argc, const char *argv[])
   print_nfc_target(&nt, false);
 
 // Guessing size
-  if ((nt.nti.nai.abtAtqa[1] & 0x02) == 0x02)
+  if ((nt.nti.nai.abtAtqa[1] & 0x02) == 0x02 || nt.nti.nai.btSak == 0x18)
 // 4K
     uiBlocks = 0xff;
   else if (nt.nti.nai.btSak == 0x09)


### PR DESCRIPTION
### Integrates new 4K Magic 'Gen B' card.
Integrates a new type of Chinese Magic 4K card, 'generation b'. This chipset was [recently integrated](http://www.proxmark.org/forum/viewtopic.php?id=4512) into the proxmark codebase, so it seems to make sense to provide compatibility here. 

The chipset in question only needs the command 0x40 to be unlocked, but does not provide an ACK to this command. As such, nfc-mfclassic now will allow for 'failed' unlock commands, but will provide sensible failure messages for cards that cannot be unlocked, ie:


## nfc-mfclassic
```
./nfc-mfclassic R a u /tmp/4k.dmp
NFC reader: PN532 board via UART opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  04
       UID (NFCID1): 9c  21  45  75
      SAK (SEL_RES): 08
Guessing size: seems to be a 1024-byte card
Sent bits:     50  00  57  cd
Sent bits:     40 (7 bits)
Warning: Unlock command [1/2]: failed / not acknowledged.
Reading out 64 blocks |!
failed to read trailer block 0x3f
Supplied card unable to perform unlocked read / writes.
```

For cards that can be unlocked, behaviour as as per normal:
```
./nfc-mfclassic R a /tmp/1k.dNFC reader: PN532 board via UART opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  04
       UID (NFCID1): c2  a8  45  6a
      SAK (SEL_RES): 08
Guessing size: seems to be a 1024-byte card
Sent bits:     50  00  57  cd
Sent bits:     40 (7 bits)
Received bits: a (4 bits)
Sent bits:     43
Received bits: 0a
Card unlocked
Reading out 64 blocks |................................................................|
Done, 64 of 64 blocks read.
Writing data to file: /tmp/1k.dmp ...Done.
```

For the 4K GenB magic cards, functionality is as follows:
```
./nfc-mfclassic R a u /tmp/4k.dmp
NFC reader: PN532 board via UART opened
Found MIFARE Classic card:
ISO/IEC 14443A (106 kbps) target:
    ATQA (SENS_RES): 00  04
       UID (NFCID1): e9  12  1d  21
      SAK (SEL_RES): 18
Guessing size: seems to be a 4096-byte card
Sent bits:     50  00  57  cd
Sent bits:     40 (7 bits)
Warning: Unlock command [1/2]: failed / not acknowledged.
Reading out 256 blocks |................................................................................................................................................................................................................................................................|
Done, 256 of 256 blocks read.
Writing data to file: /tmp/4k.dmp ...Done.
```

## nfc-mfsetuid
nfc-mfsetuid is also updated to integrate this card.

```
$ ./nfc-mfclassic R a u /tmp/4k-orig.dmp
Found MIFARE Classic card:
       UID (NFCID1): e9  1b  92  21

$ ../examples/nfc-mfsetuid
NFC reader: PN532 board via UART opened
Sent bits:     26 (7 bits)
Received bits: 04  00
Sent bits:     93  20
Received bits: e9  1b  92  21  41
Sent bits:     93  70  e9  1b  92  21  41  0d  f5
Received bits: 18  37  cd

Found tag with
 UID: e91b9221
ATQA: 0004
 SAK: 18

Sent bits:     50  00  57  cd
Sent bits:     40 (7 bits)
Warning: Unlock command [1/2]: failed / not acknowledged.
Sent bits:     a0  00  5f  b1
Received bits: 0a
Sent bits:     01  23  45  67  00  08  04  00  46  59  25  58  49  10  23  02  23  eb
Received bits: 0a

$ ./nfc-list
       UID (NFCID1): 01  23  45  67
      SAK (SEL_RES): 18
```

Thanks for your consideration.