### PR TITLE
Fix build on Windows (pn53x_transceive() usability in examples)

### DIFF
--- a/include/nfc/nfc.h
+++ b/include/nfc/nfc.h
@@ -131,6 +131,8 @@ NFC_EXPORT int nfc_device_get_supported_baud_rate_target_mode(nfc_device *pnd, c
 NFC_EXPORT int nfc_device_set_property_int(nfc_device *pnd, const nfc_property property, const int value);
 NFC_EXPORT int nfc_device_set_property_bool(nfc_device *pnd, const nfc_property property, const bool bEnable);
 
+NFC_EXPORT int pn53x_transceive(struct nfc_device *pnd, const uint8_t *pbtTx, const size_t szTx, uint8_t *pbtRx, const size_t szRxLen, int timeout);
+
 /* Misc. functions */
 NFC_EXPORT void iso14443a_crc(uint8_t *pbtData, size_t szLen, uint8_t *pbtCrc);
 NFC_EXPORT void iso14443a_crc_append(uint8_t *pbtData, size_t szLen);

--- a/libnfc/chips/pn53x.h
+++ b/libnfc/chips/pn53x.h
@@ -302,7 +302,6 @@ extern const uint8_t pn53x_ack_frame[PN53x_ACK_FRAME__LEN];
 extern const uint8_t pn53x_nack_frame[PN53x_ACK_FRAME__LEN];
 
 int    pn53x_init(struct nfc_device *pnd);
-int    pn53x_transceive(struct nfc_device *pnd, const uint8_t *pbtTx, const size_t szTx, uint8_t *pbtRx, const size_t szRxLen, int timeout);
 
 int    pn53x_set_parameters(struct nfc_device *pnd, const uint8_t ui8Value, const bool bEnable);
 int    pn53x_set_tx_bits(struct nfc_device *pnd, const uint8_t ui8Bits);


### PR DESCRIPTION
Initial report by @JONIDi12P:

## undefined reference to pn53x_transceive

i got error of undefined reference to pn53x_transceive' on file
https://github.com/nfc-tools/libnfc/blob/master/examples/pn53x-diagnose.c

on line 106+117

but i saw here
https://github.com/nfc-tools/libnfc/blob/master/libnfc/chips/pn53x.h
the header of function 
pn53x_transceive

that not depend on windows/linux
thanks