### PR TITLE
Simplify BCC handling in nfc-mfclassic

### DIFF
--- a/utils/nfc-mfclassic.1
+++ b/utils/nfc-mfclassic.1
@@ -37,14 +37,32 @@ option to format the card will reset all keys to FFFFFFFFFFFF, all data to 00 an
 
 The
 .B W
-option allows writing of special MIFARE cards that can be 'unlocked' to allow block 0
-to be overwritten. This includes UID and manufacturer data. Take care when amending UIDs to set
-the correct BCC (UID checksum). Currently only 4 byte UIDs are supported.
-
-Similarly, the
+option performs a write operation on special MIFARE Classic cards, that can
+be 'unlocked' to allow block 0 to be modified ('generation 1 Chinese magic
+cards'). Similarly, the
 .B R
 option allows an 'unlocked' read. This bypasses authentication and allows
 reading of the Key A and Key B data regardless of ACLs.
+
+The
+.B C
+option performs a write operation on special MIFARE Classic cards, that allow
+block 0 to be modified by the regular write command ('generation 2 Chinese
+magic cards'/'CUID direct-write cards'). This type of card does not reply to
+the backdoor/unlock command of generation 1 cards and is therefore harder to
+detect.
+
+*** Note that
+.B W
+,
+.B R
+and
+.B C
+options only work on Chinese magic cards (clones of MIFARE Classic cards, that
+have a modifiable block 0). Rewriting block 0 allows for modification of
+manufacturer data such as the UID. Writing bad manufacturer data into block 0
+(e.g. bad BCC) may permanantly brick a Chinese magic card. Currently, only
+4-byte UIDs are supported.
 
 R/W errors on some blocks can be either considered as critical or ignored.
 To halt on first error, specify keys with lowercase (
@@ -66,25 +84,21 @@ hexadecimal UID to the U option. For example U01ab23cd for the 4 byte UID
 parameter instead will use whatever libnfc decides which generally is the lowest
 UID.
 
-*** Note that
-.B W
-and
-.B R
-options only work on special versions of MIFARE 1K cards (Chinese clones).
-
 .SH OPTIONS
 .TP
-.BR f " | " r " | " R " | " w " | " W
+.BR f " | " r " | " R " | " w " | " W " | " C
 Perform format (
 .B f
 ) or read from (
 .B r
-) or unlocked read from (
+) or unlocked/gen1 read from (
 .B R
 ) or write to (
 .B w
-) or unlocked write to (
+) or unlocked/gen1 write to (
 .B W
+) or direct/CUID/gen2 write to (
+C
 ) card.
 .TP
 .BR a " | " A " | " b " | " B

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -316,7 +316,7 @@ read_card(int read_unlocked)
     //If the user is attempting an unlocked read, but has a direct-write type magic card, they don't
     //need to use the R mode. We'll trigger a warning and let them proceed.
     if (magic2) {
-      printf("Note: This card does not require an unlocked write (R) \n");
+      printf("Note: This card does not require an unlocked read (R) \n");
       read_unlocked = 0;
     } else {
       //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -683,6 +683,7 @@ main(int argc, const char *argv[])
 // Testing RATS
   int res;
   if ((res = get_rats()) > 0) {
+    printf("RATS support: yes\n");
     if ((res >= 10) && (abtRx[5] == 0xc1) && (abtRx[6] == 0x05)
         && (abtRx[7] == 0x2f) && (abtRx[8] == 0x2f)
         && ((nt.nti.nai.abtAtqa[1] & 0x02) == 0x00)) {
@@ -694,7 +695,8 @@ main(int argc, const char *argv[])
         && (abtRx[7] == 0x19) && (abtRx[8] == 0x10)) {
       magic2 = true;
     }
-  }
+  } else
+    printf("RATS support: no\n");
   printf("Guessing size: seems to be a %lu-byte card\n", (uiBlocks + 1) * sizeof(mifare_classic_block));
 
   if (bUseKeyFile) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -463,9 +463,11 @@ write_card(bool write_unlocked)
           memcpy(mp.mpd.abtData, mtDump.amb[uiBlock].mbd.abtData, sizeof(mp.mpd.abtData));
         // do not write a block 0 with incorrect BCC - card will be made invalid!
         if (uiBlock == 0) {
-          if ((mp.mpd.abtData[0] ^ mp.mpd.abtData[1] ^ mp.mpd.abtData[2] ^ mp.mpd.abtData[3] ^ mp.mpd.abtData[4]) != 0x00 && !magic_type2a) {
+          uint8_t computed_bcc = mp.mpd.abtData[0] ^ mp.mpd.abtData[1] ^ mp.mpd.abtData[2] ^ mp.mpd.abtData[3];
+          // magic_type2a cards seem to be fine with faulty BCC
+          if ((computed_bcc != mp.mpd.abtData[4]) && !magic_type2a) {
             printf("!\nError: incorrect BCC in MFD file!\n");
-            printf("Expecting BCC=%02X\n", mp.mpd.abtData[0] ^ mp.mpd.abtData[1] ^ mp.mpd.abtData[2] ^ mp.mpd.abtData[3]);
+            printf("Expecting BCC: %02X, found: %02X\n", computed_bcc, mp.mpd.abtData[4]);
             return false;
           }
         }

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -98,13 +98,13 @@ static size_t num_keys = sizeof(keys) / 6;
 static uint8_t abtRx[MAX_FRAME_LEN];
 static int szRxBits;
 
-uint8_t  abtHalt[4] = { 0x50, 0x00, 0x00, 0x00 };
+uint8_t abtHalt[4] = { 0x50, 0x00, 0x00, 0x00 };
 
 // special unlock command
-uint8_t  abtUnlock1[1] = { 0x40 };
-uint8_t  abtUnlock2[1] = { 0x43 };
+uint8_t abtUnlock1[1] = { 0x40 };
+uint8_t abtUnlock2[1] = { 0x43 };
 
-static  bool
+static bool
 transmit_bits(const uint8_t *pbtTx, const size_t szTxBits)
 {
   // Show transmitted command
@@ -122,7 +122,7 @@ transmit_bits(const uint8_t *pbtTx, const size_t szTxBits)
 }
 
 
-static  bool
+static bool
 transmit_bytes(const uint8_t *pbtTx, const size_t szTx)
 {
   // Show transmitted command
@@ -148,7 +148,7 @@ print_success_or_failure(bool bFailure, uint32_t *uiBlockCounter)
     *uiBlockCounter += 1;
 }
 
-static  bool
+static bool
 is_first_block(uint32_t uiBlock)
 {
   // Test if we are in the small or big sectors
@@ -158,7 +158,7 @@ is_first_block(uint32_t uiBlock)
     return ((uiBlock) % 16 == 0);
 }
 
-static  bool
+static bool
 is_trailer_block(uint32_t uiBlock)
 {
   // Test if we are in the small or big sectors
@@ -168,7 +168,7 @@ is_trailer_block(uint32_t uiBlock)
     return ((uiBlock + 1) % 16 == 0);
 }
 
-static  uint32_t
+static uint32_t
 get_trailer_block(uint32_t uiFirstBlock)
 {
   // Test if we are in the small or big sectors
@@ -181,7 +181,7 @@ get_trailer_block(uint32_t uiFirstBlock)
   return trailer_block;
 }
 
-static  bool
+static bool
 authenticate(uint32_t uiBlock)
 {
   mifare_cmd mc;
@@ -277,7 +277,7 @@ static int
 get_rats(void)
 {
   int res;
-  uint8_t  abtRats[2] = { 0xe0, 0x50};
+  uint8_t abtRats[2] = { 0xe0, 0x50};
   // Use raw send/receive methods
   if (nfc_device_set_property_bool(pnd, NP_EASY_FRAMING, false) < 0) {
     nfc_perror(pnd, "nfc_configure");
@@ -305,11 +305,11 @@ get_rats(void)
   return res;
 }
 
-static  bool
+static bool
 read_card(int read_unlocked)
 {
   int32_t iBlock;
-  bool    bFailure = false;
+  bool bFailure = false;
   uint32_t uiReadBlocks = 0;
 
   if (read_unlocked) {
@@ -375,7 +375,7 @@ read_card(int read_unlocked)
     }
     // Show if the readout went well for each block
     print_success_or_failure(bFailure, &uiReadBlocks);
-    if ((! bTolerateFailures) && bFailure)
+    if ((!bTolerateFailures) && bFailure)
       return false;
   }
   printf("|\n");
@@ -385,11 +385,11 @@ read_card(int read_unlocked)
   return true;
 }
 
-static  bool
+static bool
 write_card(int write_block_zero)
 {
   uint32_t uiBlock;
-  bool    bFailure = false;
+  bool bFailure = false;
   uint32_t uiWriteBlocks = 0;
 
   if (write_block_zero) {
@@ -449,7 +449,7 @@ write_card(int write_block_zero)
       }
     } else {
       // The first block 0x00 is read only, skip this
-      if (uiBlock == 0 && ! write_block_zero && ! magic2)
+      if (uiBlock == 0 && !write_block_zero && !magic2)
         continue;
 
 
@@ -474,7 +474,7 @@ write_card(int write_block_zero)
     }
     // Show if the write went well for each block
     print_success_or_failure(bFailure, &uiWriteBlocks);
-    if ((! bTolerateFailures) && bFailure)
+    if ((!bTolerateFailures) && bFailure)
       return false;
   }
   printf("|\n");
@@ -659,7 +659,7 @@ main(int argc, const char *argv[])
              fileUid[0], fileUid[1], fileUid[2], fileUid[3]);
       printf("Got card with UID starting as:                     %02x%02x%02x%02x\n",
              pbtUID[0], pbtUID[1], pbtUID[2], pbtUID[3]);
-      if (! bForceKeyFile) {
+      if (!bForceKeyFile) {
         printf("Aborting!\n");
         nfc_close(pnd);
         nfc_exit(context);


### PR DESCRIPTION
This PR simplifies the BCC checking in `nfc-mfclassic.c` to be more human-readable. When a faulty BCC is encountered, both the expected and the found value will be displayed.