### PR TITLE
Simplification of conditions

### DIFF
--- a/libnfc/target-subr.c
+++ b/libnfc/target-subr.c
@@ -279,7 +279,7 @@ snprint_nfc_iso14443a_info(char *dst, size_t size, const nfc_iso14443a_info *pna
             off += snprintf(dst + off, size - off, "    * Warning: Type Identification Coding length (%i)", L);
             off += snprintf(dst + off, size - off, " not matching Tk length (%" PRIdPTR ")\n", (pnai->szAtsLen - offset));
           }
-          if ((pnai->szAtsLen - offset - 2) > 0) { // Omit 2 CRC bytes
+          if ((pnai->szAtsLen - offset) != 2) { // Omit 2 CRC bytes
             uint8_t CTC = pnai->abtAts[offset];
             offset++;
             off += snprintf(dst + off, size - off, "    * Chip Type: ");
@@ -322,7 +322,7 @@ snprint_nfc_iso14443a_info(char *dst, size_t size, const nfc_iso14443a_info *pna
                 break;
             }
           }
-          if ((pnai->szAtsLen - offset) > 0) { // Omit 2 CRC bytes
+          if (pnai->szAtsLen != offset) { // Omit 2 CRC bytes
             uint8_t CVC = pnai->abtAts[offset];
             offset++;
             off += snprintf(dst + off, size - off, "    * Chip Status: ");
@@ -356,7 +356,7 @@ snprint_nfc_iso14443a_info(char *dst, size_t size, const nfc_iso14443a_info *pna
                 break;
             }
           }
-          if ((pnai->szAtsLen - offset) > 0) { // Omit 2 CRC bytes
+          if (pnai->szAtsLen != offset) { // Omit 2 CRC bytes
             uint8_t VCS = pnai->abtAts[offset];
             offset++;
             off += snprintf(dst + off, size - off, "    * Specifics (Virtual Card Selection):\n");


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warnings, found using PVS-Studio:
libnfc/libnfc/target-subr.c 282     warn    V555 The expression '(pnai->szAtsLen - offset - 2) > 0' will work as 'pnai->szAtsLen - offset != 2'.
libnfc/libnfc/target-subr.c 325     warn    V555 The expression '(pnai->szAtsLen - offset) > 0' will work as 'pnai->szAtsLen != offset'.
libnfc/libnfc/target-subr.c 359     warn    V555 The expression '(pnai->szAtsLen - offset) > 0' will work as 'pnai->szAtsLen != offset'.