### PR TITLE
Add support for fetching NFC device status

### DIFF
--- a/include/nfc/nfc.h
+++ b/include/nfc/nfc.h
@@ -141,6 +141,7 @@ NFC_EXPORT uint8_t *iso14443a_locate_historical_bytes(uint8_t *pbtAts, size_t sz
 NFC_EXPORT void nfc_free(void *p);
 NFC_EXPORT const char *nfc_version(void);
 NFC_EXPORT int nfc_device_get_information_about(nfc_device *pnd, char **buf);
+NFC_EXPORT uint8_t nfc_device_get_last_status(const nfc_device *pnd);
 
 /* String converter functions */
 NFC_EXPORT const char *str_nfc_modulation_type(const nfc_modulation_type nmt);

--- a/libnfc/chips/pn53x.c
+++ b/libnfc/chips/pn53x.c
@@ -3715,3 +3715,9 @@ pn53x_data_free(struct nfc_device *pnd)
   }
   free(pnd->chip_data);
 }
+
+uint8_t
+get_last_status(const struct nfc_device *pnd)
+{
+  return CHIP_DATA(pnd)->last_status_byte;
+}

--- a/libnfc/nfc-internal.h
+++ b/libnfc/nfc-internal.h
@@ -225,4 +225,6 @@ void prepare_initiator_data(const nfc_modulation nm, uint8_t **ppbtInitiatorData
 
 int connstring_decode(const nfc_connstring connstring, const char *driver_name, const char *bus_name, char **pparam1, char **pparam2);
 
+uint8_t get_last_status(const nfc_device *pnd);
+
 #endif // __NFC_INTERNAL_H__

--- a/libnfc/nfc.c
+++ b/libnfc/nfc.c
@@ -1310,6 +1310,17 @@ nfc_device_get_information_about(nfc_device *pnd, char **buf)
   HAL(device_get_information_about, pnd, buf);
 }
 
+/** @ingroup misc
+ * @brief Get the status byte returned for the last command run on the device
+ * @return Returns the status byte of the last run command
+ * @param pnd \a nfc_device struct pointer that represent currently used device
+ */
+uint8_t
+nfc_device_get_last_status(const nfc_device *pnd)
+{
+  return get_last_status(pnd);
+}
+
 /** @ingroup string-converter
  * @brief Convert \a nfc_baud_rate value to string
  * @return Returns nfc baud rate


### PR DESCRIPTION
This is a response to my issue #481. There's currently no way for a user of this library to retrieve the status returned from a command, which is very useful information to have access to. This patch adds in that support.