### PR TITLE
fix CMAKE_MODULE_PATH for libnfc as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_DEFINITIONS("-DHAVE_CONFIG_H")
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # make it easy to locate CMake modules for finding libraries
-SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 
 # Options
 option (LIBNFC_LOG "Enable log facility (errors, warning, info and debug messages)" ON)


### PR DESCRIPTION
## Hint

This fixes #496

## Explanation

Line 35 of [CMakeLists.txt](https://github.com/nfc-tools/libnfc/blob/a9af1927e6ad091f36428f948f1992fff550b06b/CMakeLists.txt) reads

```cmake
SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
```
This hinders the use of libnfc as a submodule e.g. using `add_subdirectory(3rdparty/libnfc EXCLUDE_FROM_ALL)` in another `CMakeLists.txt`. Also simply setting the variable instead of extending it is not by the books. The line should read

```cmake
list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
```