### PR TITLE
Add missing timeout

### DIFF
--- a/libnfc/chips/pn53x.c
+++ b/libnfc/chips/pn53x.c
@@ -1278,7 +1278,7 @@ pn53x_initiator_select_passive_target(struct nfc_device *pnd,
                                       const uint8_t *pbtInitData, const size_t szInitData,
                                       nfc_target *pnt)
 {
-  return pn53x_initiator_select_passive_target_ext(pnd, nm, pbtInitData, szInitData, pnt, 0);
+  return pn53x_initiator_select_passive_target_ext(pnd, nm, pbtInitData, szInitData, pnt, 300);
 }
 
 int


### PR DESCRIPTION
There are situations where pn533 becomes unresponsive. libnfc has
workarounds, but they can only be used if it avoids to get stuck
in some USB transfer with no timeout set. This changes fixes such
a situation.