### PR TITLE
Add undocumented option -s to nfc-relay-picc help

### DIFF
--- a/utils/nfc-relay-picc.1
+++ b/utils/nfc-relay-picc.1
@@ -34,6 +34,11 @@ tag <---> initiator (relay) <---> target (relay) <---> original reader
     Commands are read from file descriptor 3
     Responses are sent to file descriptor 4
 
+\fB-s\fP
+    Swap roles of found devices
+    Usually the first found device is used as target (emulator) and the second
+    as initiator (reader). Using this option these roles are inversed.
+
 \fB-n\fP \fIN\fP
     Adds a waiting time of \fIN\fP seconds (integer) in the loop
 

--- a/utils/nfc-relay-picc.c
+++ b/utils/nfc-relay-picc.c
@@ -99,6 +99,7 @@ print_usage(char *argv[])
   printf("\t-q\tQuiet mode. Suppress printing of relayed data (improves timing).\n");
   printf("\t-t\tTarget mode only (the one on reader side). Data expected from FD3 to FD4.\n");
   printf("\t-i\tInitiator mode only (the one on tag side). Data expected from FD3 to FD4.\n");
+  printf("\t-s\tSwap roles of found devices.\n");
   printf("\t-n N\tAdds a waiting time of N seconds (integer) in the relay to mimic long distance.\n");
 }
 


### PR DESCRIPTION
A few hours ago I had the problem that I wanted to use nfc-relay-picc but my 2 NFC devices got assigned their roles in the wrong order. When I tried to do a quick'n'dirty patch to swap this, I realyzed that this functionality already exists and there's even already an command line option for that: **-s**
Unfortunately this isn't listed in either the usage screen nor the man page, which is fixed by this pull request.