### PR TITLE
Prefer hardcoded PN533 descriptors to the real ones

### DIFF
--- a/libnfc/drivers/pn53x_usb.c
+++ b/libnfc/drivers/pn53x_usb.c
@@ -306,9 +306,9 @@ pn53x_usb_scan(const nfc_context *context, nfc_connstring connstrings[], const s
             (pn53x_usb_supported_devices[n].product_id == dev->descriptor.idProduct)) {
           // Make sure there are 2 endpoints available
           // libusb-win32 may return a NULL dev->config,
-          // or the descriptoes may be corrupted, hence
+          // or the descriptors may be corrupted, hence
           // let us assume we will use hardcoded defaults
-          // from n53x_usb_supported_devices if available.
+          // from pn53x_usb_supported_devices if available.
           // otherwise get data from the descriptors.
           if (pn53x_usb_supported_devices[n].uiMaxPacketSize == 0) {
             if (dev->config->interface == NULL || dev->config->interface->altsetting == NULL) {


### PR DESCRIPTION
PN533 easily corrupts its USB descriptors. We know that and we
already try to detect and even repair them.

However there are situations where lower software layers get
confused before libnfc can help. On Windows, libusb may set
dev->config to NULL, but we can also have a non NULL dev->config
referencing corrupted data.

In order to get more robust, let us replace the Windows libusb
specific (dev->config == NULL) test by an inconditionnal use of
hardcoded descriptors when they are available.