### PR TITLE
Fixed a typo in examples/nfc-emulate-uid.1

### DIFF
--- a/examples/nfc-emulate-uid.1
+++ b/examples/nfc-emulate-uid.1
@@ -14,7 +14,7 @@ fully customized UID but only of "random" UIDs, which always start with 0x08.
 The nfc-emulate-uid tool demonstrates that this can still be done using
 transmission of raw frames, and the desired UID can be optionally specified.
 
-This makes it a serious thread for security systems that rely only on the
+This makes it a serious threat for security systems that rely only on the
 uniqueness of the UID.
 
 Unfortunately, this example can't directly start in fully customisable


### PR DESCRIPTION
Nothing major, changed the word "thread" with the word "threat", which is the right word to use in the given context.