### PR TITLE
usbbus: Include stdint.h for uintX_t

### DIFF
--- a/libnfc/buses/usbbus.h
+++ b/libnfc/buses/usbbus.h
@@ -35,6 +35,7 @@
 
 #ifndef _WIN32
 // Under POSIX system, we use libusb (>= 0.1.12)
+#include <stdint.h>
 #include <usb.h>
 #define USB_TIMEDOUT ETIMEDOUT
 #define _usb_strerror( X ) strerror(-X)


### PR DESCRIPTION
stdint.h is needed for uintX_t typedefs which are
used to replace u_intX_t in libusb API headers in the cmake files

Define _GNU_SOURCE since thats not defined by default for musl
C library on linux

Signed-off-by: Khem Raj <raj.khem@gmail.com>