### PR TITLE
Added check for USB alternate settings

### DIFF
--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -427,14 +427,6 @@ acr122_usb_open(const nfc_context *context, const nfc_connstring connstring)
         goto free_mem;
       }
 
-      res = usb_set_altinterface(data.pudh, 0);
-      if (res < 0) {
-        log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_ERROR, "Unable to set alternate setting on USB interface (%s)", _usb_strerror(res));
-        usb_close(data.pudh);
-        // we failed to use the specified device
-        goto free_mem;
-      }
-
       // Allocate memory for the device info and specification, fill it and return the info
       pnd = nfc_device_new(context, connstring);
       if (!pnd) {

--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -427,6 +427,17 @@ acr122_usb_open(const nfc_context *context, const nfc_connstring connstring)
         goto free_mem;
       }
 
+	  // Check if there are more than 0 alternative interfaces and claim the first one
+	  if (dev->config->interface->altsetting->bAlternateSetting > 0) {
+        res = usb_set_altinterface(data.pudh, 0);
+        if (res < 0) {
+          log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_ERROR, "Unable to set alternate setting on USB interface (%s)", _usb_strerror(res));
+          usb_close(data.pudh);
+          // we failed to use the specified device
+          goto free_mem;
+        }
+	  }
+
       // Allocate memory for the device info and specification, fill it and return the info
       pnd = nfc_device_new(context, connstring);
       if (!pnd) {

--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -428,7 +428,7 @@ acr122_usb_open(const nfc_context *context, const nfc_connstring connstring)
       }
 
 	  // Check if there are more than 0 alternative interfaces and claim the first one
-	  if (dev->config->interface->altsetting->bAlternateSetting > 0) {
+      if (dev->config->interface->altsetting->bAlternateSetting > 0) {
         res = usb_set_altinterface(data.pudh, 0);
         if (res < 0) {
           log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_ERROR, "Unable to set alternate setting on USB interface (%s)", _usb_strerror(res));
@@ -436,7 +436,7 @@ acr122_usb_open(const nfc_context *context, const nfc_connstring connstring)
           // we failed to use the specified device
           goto free_mem;
         }
-	  }
+      }
 
       // Allocate memory for the device info and specification, fill it and return the info
       pnd = nfc_device_new(context, connstring);


### PR DESCRIPTION
Quick and dirty fix #535 

I'm not sure but I think, that the 072f:2200-device does not support alernative usb modes:
```shell
Bus 001 Device 013: ID 072f:2200 Advanced Card Systems, Ltd ACR122U:

# lsusb -v -s 001:013 | grep bAlter
     bAlternateSetting       0
```
Disabling allows to read and write:
```
./nfc-mfclassic r u a test.mfd
./nfc-mfclassic w u a test.mfd
```

I'm not sure. But does any of these acr122-devices has an alternative usb mode?
