### PR TITLE
Add check for Libnfc-NCI before enabling pn71xx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,7 @@ AC_HEADER_STDBOOL
 AC_CHECK_HEADERS([fcntl.h limits.h stdio.h stdlib.h stdint.h stddef.h stdbool.h sys/ioctl.h sys/param.h sys/time.h termios.h])
 AC_CHECK_HEADERS([linux/spi/spidev.h], [spi_available="yes"])
 AC_CHECK_HEADERS([linux/i2c-dev.h], [i2c_available="yes"])
+AC_CHECK_HEADERS([linux_nfc_api.h], [nfc_nci_available="yes"])
 AC_CHECK_FUNCS([memmove memset select strdup strerror strstr strtol usleep],
 	       [AC_DEFINE([_XOPEN_SOURCE], [600], [Enable POSIX extensions if present])])
 
@@ -128,6 +129,16 @@ AM_CONDITIONAL(I2C_ENABLED, [test x"$i2c_required" = x"yes"])
 if test x"$i2c_required" = x"yes"
 then
   AC_SEARCH_LIBS([clock_gettime], [rt])
+fi
+
+# Enable Libnfc-NCI if required
+if test x"$nfc_nci_required" = x"yes"
+then
+  PKG_CHECK_MODULES([LIBNFC_NCI], [libnfc-nci],
+    [AC_MSG_NOTICE([libnfc-nci present])],
+    [AC_MSG_ERROR([libnfc-nci not present but required for some drivers configuration])]
+  )
+  CFLAGS="$CPPFLAGS $LIBNFC_NCI_CFLAGS"
 fi
 
 # Documentation (default: no)

--- a/libnfc/drivers/Makefile.am
+++ b/libnfc/drivers/Makefile.am
@@ -44,7 +44,7 @@ libnfcdrivers_la_SOURCES += pn532_i2c.c pn532_i2c.h
 endif
 
 if DRIVER_PN71XX_ENABLED
-libnfcdrivers_la_LIBADD += -lnfc_nci_linux
+libnfcdrivers_la_LIBADD += @LIBNFC_NCI_LIBS@
 libnfcdrivers_la_SOURCES += pn71xx.c pn71xx.h
 endif
 

--- a/m4/libnfc_drivers.m4
+++ b/m4/libnfc_drivers.m4
@@ -37,7 +37,7 @@ AC_DEFUN([LIBNFC_ARG_WITH_DRIVERS],
                   fi
                   ;;
     all)
-                  DRIVER_BUILD_LIST="acr122_pcsc acr122_usb acr122s arygon pn53x_usb pn532_uart pn71xx pcsc"
+                  DRIVER_BUILD_LIST="acr122_pcsc acr122_usb acr122s arygon pn53x_usb pn532_uart pcsc"
 
                   if test x"$spi_available" = x"yes"
                   then
@@ -46,6 +46,10 @@ AC_DEFUN([LIBNFC_ARG_WITH_DRIVERS],
                   if test x"$i2c_available" = x"yes"
                   then
                       DRIVER_BUILD_LIST="$DRIVER_BUILD_LIST pn532_i2c"
+                  fi
+                  if test x"$nfc_nci_available" = x"yes"
+                  then
+                      DRIVER_BUILD_LIST="$DRIVER_BUILD_LIST pn71xx"
                   fi
                   ;;
   esac
@@ -112,6 +116,7 @@ AC_DEFUN([LIBNFC_ARG_WITH_DRIVERS],
                   DRIVERS_CFLAGS="$DRIVERS_CFLAGS -DDRIVER_PN532_I2C_ENABLED"
                   ;;
     pn71xx)
+                  nfc_nci_required="yes"
                   driver_pn71xx_enabled="yes"
                   DRIVERS_CFLAGS="$DRIVERS_CFLAGS -DDRIVER_PN71XX_ENABLED"
                   ;;


### PR DESCRIPTION
If the user specifically requests the driver, throw an error if it cannot find libnfc-nci.

Also use the value from pkg-config to determine the library name, instead of hard-coding it.