### PR TITLE
autotools: make example build optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,13 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CFLAGS = $(LIBNFC_CFLAGS)
 
-SUBDIRS = libnfc utils examples include contrib cmake test
+SUBDIRS = libnfc utils
+
+if EXAMPLE_ENABLED
+SUBDIRS += examples
+endif
+
+SUBDIRS += include contrib cmake test
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libnfc.pc

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,14 @@ then
 fi
 AM_CONDITIONAL(DOC_ENABLED, [test x"$enable_doc" = xyes])
 
+# Example build (default: yes)
+AC_ARG_ENABLE([example],AS_HELP_STRING([--enable-example],[Enable example build.]),[enable_example=$enableval],[enable_example="yes"])
+
+AC_MSG_CHECKING(for example build)
+AC_MSG_RESULT($enable_example)
+
+AM_CONDITIONAL(EXAMPLE_ENABLED, [test x"$enable_example" = xyes])
+
 # Dependencies
 PKG_CONFIG_REQUIRES=""
 
@@ -175,7 +183,10 @@ if test x$ac_cv_with_cutter = xyes -a x$ac_cv_use_cutter = xno; then
 fi
 AM_CONDITIONAL([WITH_CUTTER], [test "$ac_cv_use_cutter" != "no"])
 
+if test x"$enable_example" = "xyes"
+then
 AC_CHECK_READLINE
+fi
 
 # Help us to write great code ;-)
 CFLAGS="$CFLAGS -Wall -pedantic -Wextra"


### PR DESCRIPTION
This patch makes example build optional for autotools build system.

In order to keep the former behavior, example build is enabled by default.

Signed-off-by: Samuel Martin <s.martin49@gmail.com>
[Retrieved (and slightly updated to remove CMakeLists.txt) from:
https://git.buildroot.net/buildroot/tree/package/libnfc/0001-build-systems-make-example-build-optional.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>