### PR TITLE
chg: make version printing obey verbose flag

### DIFF
--- a/utils/nfc-list.c
+++ b/utils/nfc-list.c
@@ -97,10 +97,6 @@ main(int argc, const char *argv[])
     exit(EXIT_FAILURE);
   }
 
-  // Display libnfc version
-  acLibnfcVersion = nfc_version();
-  printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
-
   // Get commandline options
   for (arg = 1; arg < argc; arg++) {
     if (0 == strcmp(argv[arg], "-h")) {
@@ -125,6 +121,13 @@ main(int argc, const char *argv[])
       exit(EXIT_FAILURE);
     }
   }
+
+  // Display libnfc version
+  if (verbose) {
+    acLibnfcVersion = nfc_version();
+    printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
+  }
+
 
   /* Lazy way to open an NFC device */
 #if 0


### PR DESCRIPTION
nfc-list always prints the version number.  

```
user@happycow:~/abc$ nfc-list
nfc-list uses libnfc libnfc-1.8.0-6-g4b7791f
```

This PR aims to make that printing follow the verbose flag instead for a cleaning output.