### PR TITLE
docs: fix simple typo, mecanism -> mechanism

### DIFF
--- a/contrib/win32/libnfc/buses/uart.c
+++ b/contrib/win32/libnfc/buses/uart.c
@@ -183,7 +183,7 @@ uart_receive(serial_port sp, uint8_t *pbtRx, const size_t szRx, void *abort_p, i
   log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_DEBUG, "Timeouts are set to %lu ms", timeout_ms);
 
   // TODO Enhance the reception method
-  // - According to MSDN, it could be better to implement nfc_abort_command() mecanism using Cancello()
+  // - According to MSDN, it could be better to implement nfc_abort_command() mechanism using Cancello()
   volatile bool *abort_flag_p = (volatile bool *)abort_p;
   do {
     log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_DEBUG, "ReadFile");

--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -598,7 +598,7 @@ read:
   if (timeout == USB_INFINITE_TIMEOUT) {
     usb_timeout = USB_TIMEOUT_PER_PASS;
   } else {
-    // A user-provided timeout is set, we have to cut it in multiple chunk to be able to keep an nfc_abort_command() mecanism
+    // A user-provided timeout is set, we have to cut it in multiple chunk to be able to keep an nfc_abort_command() mechanism
     remaining_time -= USB_TIMEOUT_PER_PASS;
     if (remaining_time <= 0) {
       pnd->last_error = NFC_ETIMEOUT;

--- a/libnfc/drivers/acr122s.c
+++ b/libnfc/drivers/acr122s.c
@@ -527,7 +527,7 @@ acr122s_close(nfc_device *pnd)
   uart_close(DRIVER_DATA(pnd)->port);
 
 #ifndef WIN32
-  // Release file descriptors used for abort mecanism
+  // Release file descriptors used for abort mechanism
   close(DRIVER_DATA(pnd)->abort_fds[0]);
   close(DRIVER_DATA(pnd)->abort_fds[1]);
 #endif

--- a/libnfc/drivers/arygon.c
+++ b/libnfc/drivers/arygon.c
@@ -158,7 +158,7 @@ arygon_scan(const nfc_context *context, nfc_connstring connstrings[], const size
       }
 
 #ifndef WIN32
-      // pipe-based abort mecanism
+      // pipe-based abort mechanism
       if (pipe(DRIVER_DATA(pnd)->iAbortFds) < 0) {
         uart_close(DRIVER_DATA(pnd)->port);
         pn53x_data_free(pnd);
@@ -211,7 +211,7 @@ arygon_close_step2(nfc_device *pnd)
   uart_close(DRIVER_DATA(pnd)->port);
 
 #ifndef WIN32
-  // Release file descriptors used for abort mecanism
+  // Release file descriptors used for abort mechanism
   close(DRIVER_DATA(pnd)->iAbortFds[0]);
   close(DRIVER_DATA(pnd)->iAbortFds[1]);
 #endif
@@ -304,7 +304,7 @@ arygon_open(const nfc_context *context, const nfc_connstring connstring)
   pnd->driver = &arygon_driver;
 
 #ifndef WIN32
-  // pipe-based abort mecanism
+  // pipe-based abort mechanism
   if (pipe(DRIVER_DATA(pnd)->iAbortFds) < 0) {
     uart_close(DRIVER_DATA(pnd)->port);
     pn53x_data_free(pnd);

--- a/libnfc/drivers/pn532_uart.c
+++ b/libnfc/drivers/pn532_uart.c
@@ -136,7 +136,7 @@ pn532_uart_scan(const nfc_context *context, nfc_connstring connstrings[], const 
       CHIP_DATA(pnd)->power_mode = LOWVBAT;
 
 #ifndef WIN32
-      // pipe-based abort mecanism
+      // pipe-based abort mechanism
       if (pipe(DRIVER_DATA(pnd)->iAbortFds) < 0) {
         uart_close(DRIVER_DATA(pnd)->port);
         pn53x_data_free(pnd);
@@ -191,7 +191,7 @@ pn532_uart_close(nfc_device *pnd)
   uart_close(DRIVER_DATA(pnd)->port);
 
 #ifndef WIN32
-  // Release file descriptors used for abort mecanism
+  // Release file descriptors used for abort mechanism
   close(DRIVER_DATA(pnd)->iAbortFds[0]);
   close(DRIVER_DATA(pnd)->iAbortFds[1]);
 #endif
@@ -277,7 +277,7 @@ pn532_uart_open(const nfc_context *context, const nfc_connstring connstring)
   pnd->driver = &pn532_uart_driver;
 
 #ifndef WIN32
-  // pipe-based abort mecanism
+  // pipe-based abort mechanism
   if (pipe(DRIVER_DATA(pnd)->iAbortFds) < 0) {
     uart_close(DRIVER_DATA(pnd)->port);
     pn53x_data_free(pnd);

--- a/libnfc/drivers/pn53x_usb.c
+++ b/libnfc/drivers/pn53x_usb.c
@@ -623,7 +623,7 @@ read:
   if (timeout == USB_INFINITE_TIMEOUT) {
     usb_timeout = USB_TIMEOUT_PER_PASS;
   } else {
-    // A user-provided timeout is set, we have to cut it in multiple chunk to be able to keep an nfc_abort_command() mecanism
+    // A user-provided timeout is set, we have to cut it in multiple chunk to be able to keep an nfc_abort_command() mechanism
     remaining_time -= USB_TIMEOUT_PER_PASS;
     if (remaining_time <= 0) {
       pnd->last_error = NFC_ETIMEOUT;


### PR DESCRIPTION
There is a small typo in contrib/win32/libnfc/buses/uart.c, libnfc/drivers/acr122_usb.c, libnfc/drivers/acr122s.c, libnfc/drivers/arygon.c, libnfc/drivers/pn532_uart.c, libnfc/drivers/pn53x_usb.c.

Should read `mechanism` rather than `mecanism`.

