### PR TITLE
Include unistd.h (required because of usleep())

### DIFF
--- a/libnfc/drivers/pcsc.c
+++ b/libnfc/drivers/pcsc.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <nfc/nfc.h>
 


### PR DESCRIPTION
Compiling on MacOS catalina (./configure --with-drivers=pcsc) causes the error
pcsc.c:829:9: error: implicit declaration of function 'usleep' is invalid
      in C99 [-Werror,-Wimplicit-function-declaration]
        usleep(500000);//delay 500ms

Including unistd.h fixes this :-)