### PR TITLE
Fixes error libnfc.driver.acr122_usb Invalid RDR_to_PC_DataBlock frame

### DIFF
--- a/libnfc/drivers/acr122_usb.c
+++ b/libnfc/drivers/acr122_usb.c
@@ -612,6 +612,7 @@ read:
 
   uint8_t attempted_response = RDR_to_PC_DataBlock;
   size_t len;
+  int error, status;
 
   if (res == NFC_ETIMEOUT) {
     if (DRIVER_DATA(pnd)->abort_flag) {
@@ -623,7 +624,7 @@ read:
       goto read;
     }
   }
-  if (res < 12) {
+  if (res < 10) {
     log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_ERROR, "%s", "Invalid RDR_to_PC_DataBlock frame");
     // try to interrupt current device state
     acr122_usb_ack(pnd);
@@ -638,6 +639,17 @@ read:
   offset++;
 
   len = abtRxBuf[offset++];
+  status = abtRxBuf[7];
+  error = abtRxBuf[8];
+  if (len == 0 && error == 0xFE) { // ICC_MUTE; XXX check for more errors
+      // Do not check status; my ACR122U seemingly has status=0 in this case,
+      // even though the spec says it should have had bmCommandStatus=1
+      // and bmICCStatus=1.
+      log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_DEBUG, "%s", "Command timed out");
+      pnd->last_error = NFC_ETIMEOUT;
+      return pnd->last_error;
+  }
+
   if (!((len > 1) && (abtRxBuf[10] == 0xd5))) { // In case we didn't get an immediate answer:
     if (len != 2) {
       log_put(LOG_GROUP, LOG_CATEGORY, NFC_LOG_PRIORITY_ERROR, "%s", "Wrong reply");
@@ -666,7 +678,7 @@ read:
         goto read; // FIXME May cause some trouble on Touchatag, right ?
       }
     }
-    if (res < 12) {
+    if (res < 10) {
       // try to interrupt current device state
       acr122_usb_ack(pnd);
       pnd->last_error = NFC_EIO;
@@ -705,7 +717,7 @@ read:
 
   // Skip CCID remaining bytes
   offset += 2; // bSlot and bSeq are not used
-  offset += 2; // XXX bStatus and bError should maybe checked ?
+  offset += 2; // bStatus and bError is partially checked
   offset += 1; // bRFU should be 0x00
 
   // TFI + PD0 (CC+1)


### PR DESCRIPTION
This patch fixes the error message and nfc-poll crash reported in #284 and #570.
Though I am not the author, any chance you could merge this?