### PR TITLE
pn53x initiator set registers for ISO14443B-2 ST SRx

### DIFF
--- a/libnfc/chips/pn53x.c
+++ b/libnfc/chips/pn53x.c
@@ -1155,6 +1155,14 @@ pn53x_initiator_select_passive_target_ext(struct nfc_device *pnd,
         uint8_t abtRx[1];
         uint8_t *pbtInitData = (uint8_t *) "\x0b";
         size_t szInitData = 1;
+        
+        if ((res = pn53x_write_register(pnd, PN53X_REG_CIU_TxAuto, 0xef, 0x07)) < 0) // Initial RFOn, Tx2 RFAutoEn, Tx1 RFAutoEn
+          return res;
+        if ((res = pn53x_write_register(pnd, PN53X_REG_CIU_CWGsP, 0x3f, 0x3f)) < 0) // Conductance of the P-Driver
+          return res;
+        if ((res = pn53x_write_register(pnd, PN53X_REG_CIU_ModGsP, 0x3f, 0x12)) < 0) // Driver P-output conductance for the time of modulation
+          return res;
+        
         // Getting random Chip_ID
         if ((res = pn53x_initiator_transceive_bytes(pnd, abtInitiate, szInitiateLen, abtRx, sizeof(abtRx), timeout)) < 0) {
           if ((res == NFC_ERFTRANS) && (CHIP_DATA(pnd)->last_status_byte == 0x01)) { // Chip timeout

--- a/utils/nfc-list.c
+++ b/utils/nfc-list.c
@@ -113,7 +113,7 @@ main(int argc, const char *argv[])
         exit(EXIT_FAILURE);
       }
       // Force TypeB for all derivatives of B
-      if (mask & 0xf0)
+      if (mask & 0xd0)
         mask |= 0x08;
     } else {
       ERR("%s is not supported option.", argv[arg]);


### PR DESCRIPTION
Modification to set PN53X_REG_CIU_TxAuto, PN53X_REG_CIU_CWGsP & PN53X_REG_CIU_ModGsP registers values before init. Avoids a dummy scan in B mode before