### PR TITLE
Fixed pointer type incompatibility warnings.

### DIFF
--- a/contrib/windows.h
+++ b/contrib/windows.h
@@ -59,6 +59,6 @@
  * These declarations get rid of the "implicit declaration warning."
  */
 int setenv(const char *name, const char *value, int overwrite);
-void unsetenv(const char *name);
+int unsetenv(const char *name);
 
 #endif


### PR DESCRIPTION
Use `_putenv_s()` is a good idea which is faster than `strcat()` and `putenv()`.
I tried my best to make compatible with `setenv()` and `unsetenv()` in glibc, but there still some tests failed.
I think it's stupid to return -1 instead `errno`, Do you think it should return -1?