### PR TITLE
Fixed pointer type incompatibility warnings.

### DIFF
--- a/contrib/win32/stdlib.c
+++ b/contrib/win32/stdlib.c
@@ -34,24 +34,24 @@
 // Handle platform specific includes
 #include "contrib/windows.h"
 
-//There is no setenv()and unsetenv() in windows,but we can use putenv() instead.
+// This implementation of setenv() and unsetenv() using _putenv_s() as the
+// underlying function.
+// NOTE: unlike the POSIX functions, they return errno instead of -1 when they
+// fail, and they allow name to contain '=', which is not allowed by the POSIX
+// standard.
 int setenv(const char *name, const char *value, int overwrite)
 {
-  char *env = getenv(name);
-  if ((env && overwrite) || (!env)) {
-    char *str[32];
-    strcpy(str, name);
-    strcat(str, "=");
-    strcat(str, value);
-    return putenv(str);
+  if (!overwrite) {
+    size_t sz;
+    // Test for existence.
+    getenv_s(&sz, NULL, 0, name);
+    if (sz != 0)
+      return 0;
   }
-  return -1;
+  return _putenv_s(name, value);
 }
 
-void unsetenv(const char *name)
+int unsetenv(const char *name)
 {
-  char *str[32];
-  strcpy(str, name);
-  strcat(str, "=");
-  putenv(str);
+  return _putenv_s(name, "");
 }

--- a/contrib/windows.h
+++ b/contrib/windows.h
@@ -59,6 +59,6 @@
  * These declarations get rid of the "implicit declaration warning."
  */
 int setenv(const char *name, const char *value, int overwrite);
-void unsetenv(const char *name);
+int unsetenv(const char *name);
 
 #endif


### PR DESCRIPTION
https://github.com/nfc-tools/libnfc/pull/715
It is unnecessary to check the return value of `getenv_s(&sz, NULL, 0, name)`. I also revised the comments to explain the differ from the POSIX standards.