### PR TITLE
Cleanup unused code

### DIFF
--- a/contrib/win32/libnfc/buses/uart.c
+++ b/contrib/win32/libnfc/buses/uart.c
@@ -45,9 +45,7 @@
 #define LOG_GROUP    NFC_LOG_GROUP_COM
 #define LOG_CATEGORY "libnfc.bus.uart_win32"
 
-// Handle platform specific includes
 #include "contrib/windows.h"
-#define delay_ms( X ) Sleep( X )
 
 struct serial_port_windows {
   HANDLE  hPort;                // Serial port handle

--- a/contrib/win32/unistd.h
+++ b/contrib/win32/unistd.h
@@ -26,23 +26,20 @@
 
 /**
  * @file unistd.h
- * @brief This file intended to serve as a drop-in replacement for unistd.h on Windows
+ * @brief This file intended to serve as a drop-in replacement for unistd.h on
+ * Windows
  */
 
 #ifndef _UNISTD_H_
 #define _UNISTD_H_
 
+#ifdef __MINGW32__
+#include_next <unistd.h>
+#else
 #include "contrib/windows.h"
-
+#include "getopt.h"
 // Needed by Sleep() under Windows
-#  include <winbase.h>
-#  define sleep(X) Sleep( X * 1000)
-
-// With MinGW, getopt(3) is provided as separate header
-#if defined(WIN32) && defined(__GNUC__) /* mingw compiler */
-#include <getopt.h>
+#define sleep(X) Sleep(X * 1000)
 #endif
 
-
 #endif /* _UNISTD_H_ */
-

--- a/contrib/windows.h
+++ b/contrib/windows.h
@@ -35,7 +35,6 @@
 
 #  include <windows.h>
 #  include <winerror.h>
-#  include "win32/err.h"
 #  if defined (__MINGW32__)
 /*
  * Cheating here on the snprintf to incorporate the format argument

--- a/examples/nfc-emulate-tag.c
+++ b/examples/nfc-emulate-tag.c
@@ -189,11 +189,7 @@ main(int argc, char *argv[])
   (void) argc;
   const char *acLibnfcVersion;
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_init(&context);
   if (context == NULL) {

--- a/examples/nfc-emulate-uid.c
+++ b/examples/nfc-emulate-uid.c
@@ -130,11 +130,7 @@ main(int argc, char *argv[])
     }
   }
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_init(&context);
   if (context == NULL) {

--- a/examples/nfc-poll.c
+++ b/examples/nfc-poll.c
@@ -44,7 +44,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>

--- a/examples/nfc-relay.c
+++ b/examples/nfc-relay.c
@@ -109,11 +109,7 @@ main(int argc, char *argv[])
   // Display libnfc version
   printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_context *context;
   nfc_init(&context);

--- a/examples/nfc-st25tb.c
+++ b/examples/nfc-st25tb.c
@@ -64,10 +64,6 @@
 #include <string.h>
 #include <nfc/nfc.h>
 
-#if defined(WIN32) /* mingw compiler */
-#include <getopt.h>
-#endif
-
 #define ST25TB_SR_BLOCK_MAX_SIZE	((uint8_t) 4) // for static arrays
 typedef void(*get_info_specific) (uint8_t * systemArea);
 

--- a/examples/pn53x-diagnose.c
+++ b/examples/pn53x-diagnose.c
@@ -43,7 +43,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/examples/pn53x-tamashell.c
+++ b/examples/pn53x-tamashell.c
@@ -54,24 +54,11 @@
 #include <ctype.h>
 #include <time.h>
 
-#ifndef _WIN32
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
-
 #include <nfc/nfc.h>
 
 #include "utils/nfc-utils.h"
 #include "libnfc/chips/pn53x.h"
+#include "libnfc/nfc-internal.h"
 
 #define MAX_FRAME_LEN 264
 

--- a/libnfc/buses/uart.c
+++ b/libnfc/buses/uart.c
@@ -57,22 +57,6 @@
 #define LOG_GROUP    NFC_LOG_GROUP_COM
 #define LOG_CATEGORY "libnfc.bus.uart"
 
-#ifndef _WIN32
-// Needed by sleep() under Unix
-#  include <unistd.h>
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-// Needed by Sleep() under Windows
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
 #  if defined(__APPLE__)
 const char *serial_ports_device_radix[] = { "tty.SLAB_USBtoUART", "tty.usbserial", "tty.usbmodem", NULL };
 #  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined(__FreeBSD_kernel__)

--- a/libnfc/drivers/pcsc.c
+++ b/libnfc/drivers/pcsc.c
@@ -67,15 +67,10 @@
 #define SCARD_ATTR_VENDOR_IFD_SERIAL_NO SCARD_ATTR_VALUE(SCARD_CLASS_VENDOR_INFO, 0x0103) /**< Vendor-supplied interface device serial number. */
 #define SCARD_ATTR_ICC_TYPE_PER_ATR SCARD_ATTR_VALUE(SCARD_CLASS_ICC_STATE, 0x0304) /**< Single byte indicating smart card type */
 #else
-#ifndef _Win32
+#ifndef _WIN32
 #include <reader.h>
 #endif
 #include <winscard.h>
-#endif
-
-#ifdef WIN32
-#include <windows.h>
-#define usleep(x) Sleep((x + 999) / 1000)
 #endif
 
 #define PCSC_DRIVER_NAME "pcsc"
@@ -826,7 +821,7 @@ static int pcsc_initiator_transceive_bytes(struct nfc_device *pnd, const uint8_t
         pnd->last_error = pcsc_transmit(pnd, apdu_data, send_size, resp, &resp_len);
         memset(apdu_data, 0, sizeof(apdu_data));
         memset(resp, 0, sizeof(resp));
-        usleep(500000);//delay 500ms
+        msleep(500);//delay 500ms
       }
       // then auth
       apdu_data[0] = 0xFF;

--- a/libnfc/drivers/pn532_spi.c
+++ b/libnfc/drivers/pn532_spi.c
@@ -54,22 +54,6 @@
 #define LOG_CATEGORY "libnfc.driver.pn532_spi"
 #define LOG_GROUP    NFC_LOG_GROUP_DRIVER
 
-#ifndef _WIN32
-// Needed by sleep() under Unix
-#  include <unistd.h>
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-// Needed by Sleep() under Windows
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
 // Internal data structs
 const struct pn53x_io pn532_spi_io;
 struct pn532_spi_data {

--- a/libnfc/nfc-internal.h
+++ b/libnfc/nfc-internal.h
@@ -33,10 +33,6 @@
 #define __NFC_INTERNAL_H__
 
 #include <stdbool.h>
-#include <err.h>
-#if !defined(_MSC_VER)
-#  include <sys/time.h>
-#endif
 
 #include "nfc/nfc.h"
 
@@ -61,6 +57,22 @@
 #endif
 #ifndef MAX
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef _WIN32
+// Needed by sleep() under Unix
+#  include <unistd.h>
+#  include <time.h>
+#  define msleep(x) do { \
+    struct timespec xsleep; \
+    xsleep.tv_sec = x / 1000; \
+    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
+    nanosleep(&xsleep, NULL); \
+  } while (0)
+#else
+// Needed by Sleep() under Windows
+#  include <windows.h>
+#  define msleep Sleep
 #endif
 
 /*

--- a/utils/nfc-list.c
+++ b/utils/nfc-list.c
@@ -44,7 +44,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -54,12 +54,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifndef _WIN32
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
-
 #include <nfc/nfc.h>
 
 #include "mifare.h"

--- a/utils/nfc-read-forum-tag3.c
+++ b/utils/nfc-read-forum-tag3.c
@@ -62,10 +62,6 @@
 
 #include "nfc-utils.h"
 
-#if defined(WIN32) /* mingw compiler */
-#include <getopt.h>
-#endif
-
 static nfc_device *pnd;
 static nfc_context *context;
 

--- a/utils/nfc-relay-picc.c
+++ b/utils/nfc-relay-picc.c
@@ -199,11 +199,7 @@ main(int argc, char *argv[])
   // Display libnfc version
   printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_context *context;
   nfc_init(&context);

--- a/utils/nfc-scan-device.c
+++ b/utils/nfc-scan-device.c
@@ -43,7 +43,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/utils/nfc-utils.c
+++ b/utils/nfc-utils.c
@@ -38,7 +38,6 @@
  * @brief Provide some examples shared functions like print, parity calculation, options parsing.
  */
 #include <nfc/nfc.h>
-#include <err.h>
 
 #include "nfc-utils.h"
 


### PR DESCRIPTION
I also moved `msleep()` macro definition to `nfc-internal.h` and remove `#include <err.h>` due to it only used in `nfc-utils.h`.