### PR TITLE
Create PN532 UART sample config for Raspberry Pi 5, fix older Raspberry Pi configuration

### DIFF
--- a/contrib/libnfc/pn532_uart_on_rpi.conf.sample
+++ b/contrib/libnfc/pn532_uart_on_rpi.conf.sample
@@ -1,5 +1,9 @@
 ## Typical configuration file for PN532 device on R-Pi connected using UART
 ## Note: to use UART port on R-Pi, you have to disable linux serial console:
 ##   http://learn.adafruit.com/adafruit-nfc-rfid-on-raspberry-pi/freeing-uart-on-the-pi
+##
+## For more information about UART differences between R-Pi models, visit:
+##   https://www.raspberrypi.com/documentation/computers/configuration.html#configure-uarts
+##
 name = "PN532 board via UART"
 connstring = pn532_uart:/dev/ttyAMA0

--- a/contrib/libnfc/pn532_uart_on_rpi_3.conf.sample
+++ b/contrib/libnfc/pn532_uart_on_rpi_3.conf.sample
@@ -4,19 +4,27 @@
 ## use the PN532 device with the "mini UART", which is still hijacked by the linux kernel 
 ## as a serial console
 ##
+## For more information about UART differences between R-Pi models, visit:
+##   https://www.raspberrypi.com/documentation/computers/configuration.html#configure-uarts
+##
 ## Tested recipe with PN532 breakout from Adafruit
 ##
-## To enable uart on GPIO, add this line to bottom of /boot/config.txt
+## To enable uart on GPIO, add this line to bottom of /boot/firmware/config.txt
 ## enable_uart=1
+##
+## If you are using an earlier version of Raspberry Pi OS (prior to Bookworm),
+## the config file is available instead on /boot/config.txt.
 ##
 ## Stop and disable serial console:
 ## $ sudo systemctl stop serial-getty@ttyS0.service
 ## $ sudo systemctl disable serial-getty@ttyS0.service
 ##
-## Remove console from /boot/cmdline.txt by removing: 
+## Remove console from /boot/firmware/cmdline.txt by removing: 
 ## console=serial0,115200 Save and reboot for changes to take effect.
+##
+## If you are using an earlier version of Raspberry Pi OS (prior to Bookworm),
+## the config file is available instead on /boot/cmdline.txt.
 ##
 name = "PN532 board via UART"
 connstring = pn532_uart:/dev/ttyS0
 allow_intrusive_scan = true
-

--- a/contrib/libnfc/pn532_uart_on_rpi_5.conf.sample
+++ b/contrib/libnfc/pn532_uart_on_rpi_5.conf.sample
@@ -1,21 +1,22 @@
-## Typical configuration file for PN532 device on R-Pi 5 connected using miniUART
-## Note: Changes have been made to R-Pi 5 with the removal of the /dev/ttyS0 address
-## in favor of /dev/ttyAMA0. Additionally, the /boot/cmdline.txt has been replaced
-## with /boot/firmware/cmdline.txt.
+## Typical configuration file for PN532 device on R-Pi 5
+## Note: Changes have been made to R-Pi 5 with the removal of the mini UART
+## (/dev/ttyS0), hence the module can be accessed through the original R-Pi
+## UART address (/dev/ttyAMA0).
 ##
-## Tested recipe with generic PN532 module (common clones of the Elechouse module)
+## For more information about UART differences between R-Pi models, visit:
+##   https://www.raspberrypi.com/documentation/computers/configuration.html#configure-uarts
 ##
-## To enable uart on GPIO, add this line to bottom of /boot/config.txt
+## This configuration is almost identical to pn532_uart_on_rpi.conf.sample
+## except the allow_intrusive_scan option from the R-Pi 3 sample.
+##
+## Tested recipe with generic PN532 module (common Elechouse module clones)
+##
+## To enable uart on GPIO, add this line to bottom of /boot/firmware/config.txt
 ## enable_uart=1
 ##
-## Stop and disable serial console:
-## $ sudo systemctl stop serial-getty@ttyAMA0.service
-## $ sudo systemctl disable serial-getty@ttyAMA0.service
-##
-## Remove console from /boot/firmware/cmdline.txt by removing: 
-## console=serial0,115200 Save and reboot for changes to take effect.
+## If you are using an earlier version of Raspberry Pi OS (prior to Bookworm),
+## the config file is available instead on /boot/config.txt.
 ##
 name = "PN532 board via UART"
 connstring = pn532_uart:/dev/ttyAMA0
 allow_intrusive_scan = true
-

--- a/contrib/libnfc/pn532_uart_on_rpi_5.conf.sample
+++ b/contrib/libnfc/pn532_uart_on_rpi_5.conf.sample
@@ -1,0 +1,21 @@
+## Typical configuration file for PN532 device on R-Pi 5 connected using miniUART
+## Note: Changes have been made to R-Pi 5 with the removal of the /dev/ttyS0 address
+## in favor of /dev/ttyAMA0. Additionally, the /boot/cmdline.txt has been replaced
+## with /boot/firmware/cmdline.txt.
+##
+## Tested recipe with generic PN532 module (common clones of the Elechouse module)
+##
+## To enable uart on GPIO, add this line to bottom of /boot/config.txt
+## enable_uart=1
+##
+## Stop and disable serial console:
+## $ sudo systemctl stop serial-getty@ttyAMA0.service
+## $ sudo systemctl disable serial-getty@ttyAMA0.service
+##
+## Remove console from /boot/firmware/cmdline.txt by removing: 
+## console=serial0,115200 Save and reboot for changes to take effect.
+##
+name = "PN532 board via UART"
+connstring = pn532_uart:/dev/ttyAMA0
+allow_intrusive_scan = true
+


### PR DESCRIPTION
The Raspberry Pi 5 no longer includes the `/dev/ttyS0` address to access the PN532 module via UART (since mini UART has been removed). Multiple sources confirm that the address is removed in favor of `/dev/ttyAMA0`.

Additionally, the configuration files have been changed since Raspberry Pi OS Bookworm, i.e. from `/boot/config.txt` to `/boot/firmware/config.txt`.

Sources:
+ https://forums.raspberrypi.com/viewtopic.php?t=368523
+ https://github.com/raspberrypi/documentation/issues/3239
+ https://www.raspberrypi.com/documentation/computers/config_txt.html 
+ https://www.raspberrypi.com/documentation/computers/configuration.html#configure-uarts