### PR TITLE
Cleanup codes

### DIFF
--- a/contrib/win32/libnfc/buses/uart.c
+++ b/contrib/win32/libnfc/buses/uart.c
@@ -45,9 +45,7 @@
 #define LOG_GROUP    NFC_LOG_GROUP_COM
 #define LOG_CATEGORY "libnfc.bus.uart_win32"
 
-// Handle platform specific includes
 #include "contrib/windows.h"
-#define delay_ms( X ) Sleep( X )
 
 struct serial_port_windows {
   HANDLE  hPort;                // Serial port handle

--- a/examples/nfc-anticol.c
+++ b/examples/nfc-anticol.c
@@ -54,10 +54,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define SAK_FLAG_ATS_SUPPORTED 0x20
-
-#define MAX_FRAME_LEN 264
-
 static uint8_t abtRx[MAX_FRAME_LEN];
 static int szRxBits;
 static size_t szRx = sizeof(abtRx);
@@ -80,7 +76,6 @@ uint8_t  abtSelectAll[2] = { 0x93, 0x20 };
 uint8_t  abtSelectTag[9] = { 0x93, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 uint8_t  abtRats[4] = { 0xe0, 0x50, 0x00, 0x00 };
 uint8_t  abtHalt[4] = { 0x50, 0x00, 0x00, 0x00 };
-#define CASCADE_BIT 0x04
 
 static  bool
 transmit_bits(const uint8_t *pbtTx, const size_t szTxBits)
@@ -144,7 +139,7 @@ transmit_bytes(const uint8_t *pbtTx, const size_t szTx)
 }
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS]\n", argv[0]);
   printf("Options:\n");
@@ -155,7 +150,7 @@ print_usage(char *argv[])
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int     arg;
 

--- a/examples/nfc-dep-initiator.c
+++ b/examples/nfc-dep-initiator.c
@@ -52,8 +52,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define MAX_FRAME_LEN 264
-
 static nfc_device *pnd;
 static nfc_context *context;
 
@@ -69,7 +67,7 @@ static void stop_dep_communication(int sig)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   nfc_target nt;
   uint8_t  abtRx[MAX_FRAME_LEN];

--- a/examples/nfc-dep-target.c
+++ b/examples/nfc-dep-target.c
@@ -51,8 +51,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define MAX_FRAME_LEN 264
-
 static nfc_device *pnd;
 static nfc_context *context;
 
@@ -68,7 +66,7 @@ static void stop_dep_communication(int sig)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   uint8_t  abtRx[MAX_FRAME_LEN];
   int  szRx;
@@ -84,7 +82,6 @@ main(int argc, const char *argv[])
     ERR("Unable to init libnfc (malloc)");
     exit(EXIT_FAILURE);
   }
-#define MAX_DEVICE_COUNT 2
   nfc_connstring connstrings[MAX_DEVICE_COUNT];
   size_t szDeviceFound = nfc_list_devices(context, connstrings, MAX_DEVICE_COUNT);
   // Little hack to allow using nfc-dep-initiator & nfc-dep-target from

--- a/examples/nfc-emulate-forum-tag2.c
+++ b/examples/nfc-emulate-forum-tag2.c
@@ -120,8 +120,8 @@ static uint8_t __nfcforum_tag2_memory_area[] = {
 #define READ 		0x30
 #define WRITE 		0xA2
 #define SECTOR_SELECT 	0xC2
-
 #define HALT 		0x50
+
 static int
 nfcforum_tag2_io(struct nfc_emulator *emulator, const uint8_t *data_in, const size_t data_in_len, uint8_t *data_out, const size_t data_out_len)
 {
@@ -161,7 +161,7 @@ nfcforum_tag2_io(struct nfc_emulator *emulator, const uint8_t *data_in, const si
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   (void)argc;
   (void)argv;

--- a/examples/nfc-emulate-tag.c
+++ b/examples/nfc-emulate-tag.c
@@ -58,7 +58,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define MAX_FRAME_LEN (264)
 #define SAK_ISO14443_4_COMPLIANT 0x20
 
 static uint8_t abtRx[MAX_FRAME_LEN];
@@ -184,16 +183,12 @@ nfc_target_emulate_tag(nfc_device *dev, nfc_target *pnt)
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   (void) argc;
   const char *acLibnfcVersion;
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_init(&context);
   if (context == NULL) {

--- a/examples/nfc-emulate-uid.c
+++ b/examples/nfc-emulate-uid.c
@@ -60,8 +60,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define MAX_FRAME_LEN 264
-
 static uint8_t abtRecv[MAX_FRAME_LEN];
 static int szRecvBits;
 static nfc_device *pnd;
@@ -86,7 +84,7 @@ intr_hdlr(int sig)
 }
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS] [UID]\n", argv[0]);
   printf("Options:\n");
@@ -97,7 +95,7 @@ print_usage(char *argv[])
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   uint8_t *pbtTx = NULL;
   size_t  szTxBits;
@@ -130,11 +128,7 @@ main(int argc, char *argv[])
     }
   }
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_init(&context);
   if (context == NULL) {

--- a/examples/nfc-mfsetuid.c
+++ b/examples/nfc-mfsetuid.c
@@ -60,10 +60,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define SAK_FLAG_ATS_SUPPORTED 0x20
-
-#define MAX_FRAME_LEN 264
-
 static uint8_t abtRx[MAX_FRAME_LEN];
 static int szRxBits;
 static uint8_t abtRawUid[12];
@@ -83,7 +79,6 @@ uint8_t  abtSelectAll[2] = { 0x93, 0x20 };
 uint8_t  abtSelectTag[9] = { 0x93, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 uint8_t  abtRats[4] = { 0xe0, 0x50, 0x00, 0x00 };
 uint8_t  abtHalt[4] = { 0x50, 0x00, 0x00, 0x00 };
-#define CASCADE_BIT 0x04
 
 // special unlock command
 uint8_t  abtUnlock1[1] = { 0x40 };
@@ -139,7 +134,7 @@ transmit_bytes(const uint8_t *pbtTx, const size_t szTx)
 }
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS] [UID|BLOCK0]\n", argv[0]);
   printf("Options:\n");
@@ -154,7 +149,7 @@ print_usage(char *argv[])
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int      arg, i;
   bool     format = false;

--- a/examples/nfc-poll.c
+++ b/examples/nfc-poll.c
@@ -44,7 +44,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
@@ -56,8 +55,6 @@
 #include <nfc/nfc-types.h>
 
 #include "utils/nfc-utils.h"
-
-#define MAX_DEVICE_COUNT 16
 
 static nfc_device *pnd = NULL;
 static nfc_context *context;
@@ -81,7 +78,7 @@ print_usage(const char *progname)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   bool verbose = false;
 

--- a/examples/nfc-relay.c
+++ b/examples/nfc-relay.c
@@ -54,9 +54,6 @@
 
 #include "utils/nfc-utils.h"
 
-#define MAX_FRAME_LEN 264
-#define MAX_DEVICE_COUNT 2
-
 static uint8_t abtReaderRx[MAX_FRAME_LEN];
 static uint8_t abtReaderRxPar[MAX_FRAME_LEN];
 static int szReaderRxBits;
@@ -77,7 +74,7 @@ intr_hdlr(int sig)
 }
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS]\n", argv[0]);
   printf("Options:\n");
@@ -86,7 +83,7 @@ print_usage(char *argv[])
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int     arg;
   bool    quiet_output = false;
@@ -109,11 +106,7 @@ main(int argc, char *argv[])
   // Display libnfc version
   printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_context *context;
   nfc_init(&context);

--- a/examples/nfc-st25tb.c
+++ b/examples/nfc-st25tb.c
@@ -64,11 +64,7 @@
 #include <string.h>
 #include <nfc/nfc.h>
 
-#if defined(WIN32) /* mingw compiler */
-#include <getopt.h>
-#endif
-
-#define ST25TB_SR_BLOCK_MAX_SIZE	((uint8_t) 4) // for static arrays
+#define ST25TB_SR_BLOCK_MAX_SIZE	((size_t) 4) // for static arrays
 typedef void(*get_info_specific) (uint8_t * systemArea);
 
 typedef struct _st_data {
@@ -89,7 +85,7 @@ const st_data * get_info(const nfc_target *pnt, bool bPrintIt);
 void display_system_info(nfc_device *pnd, const st_data * stdata);
 void print_hex(const uint8_t *pbtData, const size_t szBytes);
 
-int main(int argc, char *argv[])
+int main(int argc, char **argv)
 {
 	nfc_context *context = NULL;
 	nfc_device *pnd = NULL;

--- a/examples/pn53x-diagnose.c
+++ b/examples/pn53x-diagnose.c
@@ -43,7 +43,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -52,10 +51,8 @@
 #include "utils/nfc-utils.h"
 #include "libnfc/chips/pn53x.h"
 
-#define MAX_DEVICE_COUNT 16
-
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   size_t  i;
   nfc_device *pnd = NULL;

--- a/examples/pn53x-sam.c
+++ b/examples/pn53x-sam.c
@@ -56,7 +56,6 @@
 #include "utils/nfc-utils.h"
 #include "libnfc/chips/pn53x.h"
 
-#define MAX_FRAME_LEN 264
 #define TIMEOUT 60              // secs.
 
 static void
@@ -78,7 +77,7 @@ wait_one_minute(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   (void) argc;
   (void) argv;

--- a/examples/pn53x-tamashell.c
+++ b/examples/pn53x-tamashell.c
@@ -54,28 +54,13 @@
 #include <ctype.h>
 #include <time.h>
 
-#ifndef _WIN32
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
-
 #include <nfc/nfc.h>
 
 #include "utils/nfc-utils.h"
 #include "libnfc/chips/pn53x.h"
+#include "libnfc/nfc-internal.h"
 
-#define MAX_FRAME_LEN 264
-
-int main(int argc, const char *argv[])
+int main(int argc, char **argv)
 {
   nfc_device *pnd;
   uint8_t abtRx[MAX_FRAME_LEN];

--- a/libnfc/buses/uart.c
+++ b/libnfc/buses/uart.c
@@ -57,22 +57,6 @@
 #define LOG_GROUP    NFC_LOG_GROUP_COM
 #define LOG_CATEGORY "libnfc.bus.uart"
 
-#ifndef _WIN32
-// Needed by sleep() under Unix
-#  include <unistd.h>
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-// Needed by Sleep() under Windows
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
 #  if defined(__APPLE__)
 const char *serial_ports_device_radix[] = { "tty.SLAB_USBtoUART", "tty.usbserial", "tty.usbmodem", NULL };
 #  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined(__FreeBSD_kernel__)

--- a/libnfc/chips/pn53x.c
+++ b/libnfc/chips/pn53x.c
@@ -50,6 +50,9 @@
 #define LOG_CATEGORY "libnfc.chip.pn53x"
 #define LOG_GROUP NFC_LOG_GROUP_CHIP
 
+#define SAK_ISO14443_4_COMPLIANT 0x20
+#define SAK_ISO18092_COMPLIANT   0x40
+
 const uint8_t pn53x_ack_frame[] = { 0x00, 0x00, 0xff, 0x00, 0xff, 0x00 };
 const uint8_t pn53x_nack_frame[] = { 0x00, 0x00, 0xff, 0xff, 0x00, 0x00 };
 static const uint8_t pn53x_error_frame[] = { 0x00, 0x00, 0xff, 0x01, 0xff, 0x7f, 0x81, 0x00 };
@@ -2367,8 +2370,6 @@ pn53x_initiator_target_is_present(struct nfc_device *pnd, const nfc_target *pnt)
   return pnd->last_error = ret;
 }
 
-#define SAK_ISO14443_4_COMPLIANT 0x20
-#define SAK_ISO18092_COMPLIANT   0x40
 int
 pn53x_target_init(struct nfc_device *pnd, nfc_target *pnt, uint8_t *pbtRx, const size_t szRxLen, int timeout)
 {

--- a/libnfc/drivers/pcsc.c
+++ b/libnfc/drivers/pcsc.c
@@ -67,15 +67,10 @@
 #define SCARD_ATTR_VENDOR_IFD_SERIAL_NO SCARD_ATTR_VALUE(SCARD_CLASS_VENDOR_INFO, 0x0103) /**< Vendor-supplied interface device serial number. */
 #define SCARD_ATTR_ICC_TYPE_PER_ATR SCARD_ATTR_VALUE(SCARD_CLASS_ICC_STATE, 0x0304) /**< Single byte indicating smart card type */
 #else
-#ifndef _Win32
+#ifndef _WIN32
 #include <reader.h>
 #endif
 #include <winscard.h>
-#endif
-
-#ifdef WIN32
-#include <windows.h>
-#define usleep(x) Sleep((x + 999) / 1000)
 #endif
 
 #define PCSC_DRIVER_NAME "pcsc"
@@ -84,6 +79,8 @@
 
 #define LOG_GROUP    NFC_LOG_GROUP_DRIVER
 #define LOG_CATEGORY "libnfc.driver.pcsc"
+
+#define SAK_ISO14443_4_COMPLIANT 0x20
 
 static const char *supported_devices[] = {
   "ACS ACR122",         // ACR122U & Touchatag, last version
@@ -370,8 +367,7 @@ static int pcsc_props_to_target(struct nfc_device *pnd, uint8_t it, const uint8_
             memcpy(pnt->nti.nai.abtAts, ats, ats_len);
             pnt->nti.nai.szAtsLen = ats_len;
           } else {
-            /* SAK_ISO14443_4_COMPLIANT */
-            pnt->nti.nai.btSak = 0x20;
+            pnt->nti.nai.btSak = SAK_ISO14443_4_COMPLIANT;
             /* Choose TL, TA, TB, TC according to Mifare DESFire */
             memcpy(pnt->nti.nai.abtAts, "\x75\x77\x81\x02", 4);
             /* copy historical bytes */
@@ -826,7 +822,7 @@ static int pcsc_initiator_transceive_bytes(struct nfc_device *pnd, const uint8_t
         pnd->last_error = pcsc_transmit(pnd, apdu_data, send_size, resp, &resp_len);
         memset(apdu_data, 0, sizeof(apdu_data));
         memset(resp, 0, sizeof(resp));
-        usleep(500000);//delay 500ms
+        msleep(500);
       }
       // then auth
       apdu_data[0] = 0xFF;

--- a/libnfc/drivers/pn532_spi.c
+++ b/libnfc/drivers/pn532_spi.c
@@ -54,22 +54,6 @@
 #define LOG_CATEGORY "libnfc.driver.pn532_spi"
 #define LOG_GROUP    NFC_LOG_GROUP_DRIVER
 
-#ifndef _WIN32
-// Needed by sleep() under Unix
-#  include <unistd.h>
-#  include <time.h>
-#  define msleep(x) do { \
-    struct timespec xsleep; \
-    xsleep.tv_sec = x / 1000; \
-    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
-    nanosleep(&xsleep, NULL); \
-  } while (0)
-#else
-// Needed by Sleep() under Windows
-#  include <winbase.h>
-#  define msleep Sleep
-#endif
-
 // Internal data structs
 const struct pn53x_io pn532_spi_io;
 struct pn532_spi_data {

--- a/libnfc/nfc-internal.h
+++ b/libnfc/nfc-internal.h
@@ -33,13 +33,8 @@
 #define __NFC_INTERNAL_H__
 
 #include <stdbool.h>
-#include <err.h>
-#if !defined(_MSC_VER)
-#  include <sys/time.h>
-#endif
 
 #include "nfc/nfc.h"
-
 #include "log.h"
 
 /**
@@ -61,6 +56,22 @@
 #endif
 #ifndef MAX
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef _WIN32
+// Needed by sleep() under Unix
+#  include <unistd.h>
+#  include <time.h>
+#  define msleep(x) do { \
+    struct timespec xsleep; \
+    xsleep.tv_sec = x / 1000; \
+    xsleep.tv_nsec = (x - xsleep.tv_sec * 1000) * 1000 * 1000; \
+    nanosleep(&xsleep, NULL); \
+  } while (0)
+#else
+// Needed by Sleep() under Windows
+#  include <windows.h>
+#  define msleep Sleep
 #endif
 
 /*

--- a/utils/nfc-barcode.c
+++ b/utils/nfc-barcode.c
@@ -50,14 +50,12 @@
 
 #include "nfc-utils.h"
 
-#define MAX_FRAME_LEN 264
-
 static nfc_device *pnd;
 
 bool    verbose = false;
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS]\n", argv[0]);
   printf("Options:\n");
@@ -135,7 +133,7 @@ decode_barcode(uint8_t *pbtBarcode, const size_t szBarcode)
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int     arg;
 

--- a/utils/nfc-emulate-forum-tag4.c
+++ b/utils/nfc-emulate-forum-tag4.c
@@ -316,7 +316,7 @@ usage(char *progname)
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int options = 0;
   nfc_target nt = {

--- a/utils/nfc-jewel.c
+++ b/utils/nfc-jewel.c
@@ -198,7 +198,7 @@ write_card(void)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   bool    bReadAction;
   FILE   *pfDump;

--- a/utils/nfc-list.c
+++ b/utils/nfc-list.c
@@ -44,7 +44,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -53,9 +52,6 @@
 #include <nfc/nfc.h>
 
 #include "nfc-utils.h"
-
-#define MAX_DEVICE_COUNT 16
-#define MAX_TARGET_COUNT 16
 
 static nfc_device *pnd;
 
@@ -80,7 +76,7 @@ print_usage(const char *progname)
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   (void) argc;
   const char *acLibnfcVersion;

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -50,15 +50,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-
 #include <string.h>
 #include <ctype.h>
-
-#ifndef _WIN32
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
 
 #include <nfc/nfc.h>
 
@@ -99,8 +92,6 @@ static const nfc_modulation nmMifare = {
 };
 
 static size_t num_keys = sizeof(keys) / 6;
-
-#define MAX_FRAME_LEN 264
 
 static uint8_t abtRx[MAX_FRAME_LEN];
 static int szRxBits;
@@ -557,7 +548,7 @@ print_usage(const char *pcProgramName)
 
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   action_t atAction = ACTION_USAGE;
   uint8_t *pbtUID;

--- a/utils/nfc-mfultralight.c
+++ b/utils/nfc-mfultralight.c
@@ -59,7 +59,6 @@
 #include "nfc-utils.h"
 #include "mifare.h"
 
-#define MAX_TARGET_COUNT 16
 #define MAX_UID_LEN 10
 
 #define EV1_NONE    0
@@ -92,8 +91,6 @@ uint8_t  abtPWAuth[7] = { 0x1B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
 //Halt command
 uint8_t  abtHalt[4] = { 0x50, 0x00, 0x00, 0x00 };
-
-#define MAX_FRAME_LEN 264
 
 static uint8_t abtRx[MAX_FRAME_LEN];
 static int szRxBits;
@@ -492,7 +489,7 @@ static size_t str_to_uid(const char *str, uint8_t *uid)
 }
 
 static void
-print_usage(const char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s r|w <dump.mfd> [OPTIONS]\n", argv[0]);
   printf("Arguments:\n");
@@ -510,7 +507,7 @@ print_usage(const char *argv[])
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   int     iAction = 0;
   size_t  iDumpSize = sizeof(mifareul_tag);

--- a/utils/nfc-read-forum-tag3.c
+++ b/utils/nfc-read-forum-tag3.c
@@ -62,10 +62,6 @@
 
 #include "nfc-utils.h"
 
-#if defined(WIN32) /* mingw compiler */
-#include <getopt.h>
-#endif
-
 static nfc_device *pnd;
 static nfc_context *context;
 
@@ -165,7 +161,7 @@ nfc_forum_tag_type3_check(nfc_device *dev, const nfc_target *nt, const uint16_t 
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   (void)argc;
   (void)argv;

--- a/utils/nfc-relay-picc.c
+++ b/utils/nfc-relay-picc.c
@@ -55,15 +55,11 @@
 #include <stdint.h>
 #include <string.h>
 #include <signal.h>
-
 #include <unistd.h>
 
 #include <nfc/nfc.h>
 
 #include "nfc-utils.h"
-
-#define MAX_FRAME_LEN 264
-#define MAX_DEVICE_COUNT 2
 
 static uint8_t abtCapdu[MAX_FRAME_LEN];
 static size_t szCapduLen;
@@ -91,7 +87,7 @@ intr_hdlr(int sig)
 }
 
 static void
-print_usage(char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS]\n", argv[0]);
   printf("Options:\n");
@@ -158,7 +154,7 @@ static int scan_hex_fd3(uint8_t *pbtData, size_t *pszBytes, const char *pchPrefi
 }
 
 int
-main(int argc, char *argv[])
+main(int argc, char **argv)
 {
   int     arg;
   const char *acLibnfcVersion = nfc_version();
@@ -199,11 +195,7 @@ main(int argc, char *argv[])
   // Display libnfc version
   printf("%s uses libnfc %s\n", argv[0], acLibnfcVersion);
 
-#ifdef WIN32
-  signal(SIGINT, (void (__cdecl *)(int)) intr_hdlr);
-#else
   signal(SIGINT, intr_hdlr);
-#endif
 
   nfc_context *context;
   nfc_init(&context);

--- a/utils/nfc-scan-device.c
+++ b/utils/nfc-scan-device.c
@@ -43,7 +43,6 @@
 #  include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <err.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -53,13 +52,13 @@
 
 #include "nfc-utils.h"
 
+#undef MAX_DEVICE_COUNT
 #define MAX_DEVICE_COUNT 16
-#define MAX_TARGET_COUNT 16
 
 static nfc_device *pnd;
 
 static void
-print_usage(const char *argv[])
+print_usage(char **argv)
 {
   printf("Usage: %s [OPTIONS]\n", argv[0]);
   printf("Options:\n");
@@ -69,7 +68,7 @@ print_usage(const char *argv[])
 }
 
 int
-main(int argc, const char *argv[])
+main(int argc, char **argv)
 {
   const char *acLibnfcVersion;
   size_t  i;

--- a/utils/nfc-utils.c
+++ b/utils/nfc-utils.c
@@ -38,7 +38,6 @@
  * @brief Provide some examples shared functions like print, parity calculation, options parsing.
  */
 #include <nfc/nfc.h>
-#include <err.h>
 
 #include "nfc-utils.h"
 

--- a/utils/nfc-utils.h
+++ b/utils/nfc-utils.h
@@ -92,6 +92,12 @@
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #endif
 
+#define CASCADE_BIT 0x04
+#define MAX_FRAME_LEN 264
+#define MAX_DEVICE_COUNT 2
+#define MAX_TARGET_COUNT 16
+#define SAK_FLAG_ATS_SUPPORTED 0x20
+
 uint8_t  oddparity(const uint8_t bt);
 void    oddparity_bytes_ts(const uint8_t *pbtData, const size_t szLen, uint8_t *pbtPar);
 


### PR DESCRIPTION
This PR is a part of #730.
I removed `#include <err.h>` as it was only used in nfc-utils.h and moved `msleep()` macro to nfc-internal.h for better organization.